### PR TITLE
Normalize CSS

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -116,17 +116,11 @@ button {
   color: inherit;
   padding: .4em 1.2em;
   background-color: transparent;
-  cursor: pointer;
 }
-button:hover,
-button:focus {
-  background-color: hsla(0,0%,100%,.1);
-}
+button:focus,
 button:active {
-  background-color: transparent;
-}
-button:focus {
   outline: none;
+  border-color: hsl(0,0%,88%);
 }
 
 
@@ -161,23 +155,14 @@ pre code {
   padding: .5em 1em;
   line-height: 1.5;
   font-weight: 600;
-  cursor: pointer;
   border-left: 2px solid;
   transition: border-color .12s;
-}
-.content h2:hover,
-.content h2:focus {
-  border-left-color: hsl(0,0%,88%);
-}
-.content h2:active {
-  border-left-color: transparent;
-}
-.content h2:focus {
   outline: none;
 }
-
-.active h2,
-.active h2:hover {
+.content h2:active {
+  border-color: hsl(0,0%,88%);
+}
+.active h2 {
   border-left-color: transparent;
 }
 

--- a/assets/css/nativize.css
+++ b/assets/css/nativize.css
@@ -1,5 +1,5 @@
 /*
-** normalize.css
+** nativize.css
 ** Makes the UI feel more native
 */
 
@@ -33,7 +33,11 @@ a {
   text-decoration: none;
 }
 
-a:hover,
-a:focus {
+
+/* External links */
+
+a[href]:hover,
+a[href]:focus {
+  cursor: pointer;
   text-decoration: underline;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,11 +20,6 @@ body {
   overflow-y: hidden; /* Prevents rubber-band scrolling of the whole "page" */
 }
 
-a {
-  text-decoration: none;
-  cursor: pointer;
-}
-
 h1,
 h2,
 h3 {

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
   <meta charset="utf-8">
   <title>Electron API Demos</title>
 
-  <link rel="stylesheet" href="assets/css/style.css">
+  <link rel="stylesheet" href="assets/css/nativize.css">
   <link rel="stylesheet" href="assets/css/fonts.css">
+  <link rel="stylesheet" href="assets/css/style.css">
   <link rel="stylesheet" href="assets/css/colors.css">
   <link rel="stylesheet" href="assets/css/nav.css">
   <link rel="stylesheet" href="assets/css/content.css">


### PR DESCRIPTION
Initial PR for #17. Not sure how far it should go. Currently it:
- [x] Disables text selection except for the code.
- [x] Disables dragging.
- [x] No pointer for  `<a>` and `<button>`, just underline for `<a>` on hover.

Also, it uses `@import 'normalize.css';` which I think isn't recommended for serving over the network, but locally maybe ok.
