### PR TITLE
Prevent Rubber banding 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,7 +16,6 @@ body {
   margin: 0;
   height: 100%;
   display: flex;
-  min-width: 680px; /* Double the nav */
 }
 
 h1,

--- a/main.js
+++ b/main.js
@@ -12,7 +12,7 @@ glob('main-process/**/*.js', function (error, files) {
 });
 
 function createWindow () {
-  mainWindow = new BrowserWindow({ width: 920, height: 900 });
+  mainWindow = new BrowserWindow({ width: 920, 'min-width': 680, height: 900 });
   mainWindow.loadURL('file://' + __dirname + '/index.html');
   mainWindow.on('closed', function() {
     mainWindow = null;


### PR DESCRIPTION
I was still getting the rubber banding of the entire top page and I think that the `overflow: hidden;` on `html` rather than `body` is what actually stops it—at least for me?

Were you still getting the elastic bounce @simurai? What do you think about this?
