### PR TITLE
Start App with No Selections

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
         <svg class="nav-icon" viewBox="0 0 14 16"><use xlink:href="#icon-windows"></use></svg>
         Windows
       </h5>
-      <button type="button" data-view="windows" class="nav-link is-selected">Create and manage <em>windows</em></button>
+      <button type="button" data-view="windows" class="nav-link">Create and manage <em>windows</em></button>
     </section>
 
     <section class="nav-item menu">


### PR DESCRIPTION
I noticed that now that we have the about/welcome page we should remove the intial selection of the windows demo.

Super small PR but just wanted to make sure people saw it come through and were :ok: with it or didn't have another idea for the state of the side bar on start up. cc @simurai 

![screen shot 2016-03-06 at 11 27 32 am](https://cloud.githubusercontent.com/assets/1305617/13556448/d4badc08-e38e-11e5-9d5c-8d02937b7f2b.png)
