### PR TITLE
Add signing support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "start": "electron .",
     "lint": "semistandard --verbose | snazzy",
     "test": "mocha tests && npm run lint",
+    "sign-win": "signcode -spc ~/electron-api-demos.spc -v ~/electron-api-demos.pvk -a sha1 -$ commercial -n 'Electron API Demos' -i http://electron.atom.io  -t http://timestamp.verisign.com/scripts/timstamp.dll -tr 10 '../EAD-Packages/Electron API Demos-win32-ia32/Electron API Demos.exe'",
     "pack-mac": "electron-packager . 'Electron API Demos' --platform=darwin --arch=x64 --version=0.36.9 --icon=assets/app-icon/mac/app.icns --prune=true --out='../EAD-Packages' --sign='Developer ID Application: GitHub'",
-    "pack-win": "electron-packager . 'Electron API Demos' --platform=win32 --arch=ia32   --version=0.36.9 --icon=assets/app-icon/win/app.ico --prune=true --out='../EAD-Packages'",
+    "pack-win": "electron-packager . 'Electron API Demos' --platform=win32 --arch=ia32   --version=0.36.9 --icon=assets/app-icon/win/app.ico --prune=true --out='../EAD-Packages' --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos' && npm run sign-win",
     "pack-win-win": "electron-packager . Electron API Demos --platform=win32 --arch=ia32   --version=0.36.9 --icon=assets/app-icon/win/app.ico --prune=true --out=EAD-Packages",
     "pack-lin": "electron-packager . 'Electron API Demos' --platform=linux --arch=x64   --version=0.36.9 --icon=assets/app-icon/png/64.png --prune=true --out='../EAD-Packages'",
     "package": "npm run pack-mac && npm run pack-win && npm run pack-lin"


### PR DESCRIPTION
Certs are in Box as `electron-api-demos.pvk` and  `electron-api-demos.spc` and should be installed to `~/`

/cc @jlord :pear:
