### PR TITLE
Fix code scrolling, I think

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -20,13 +20,13 @@
   pointer-events: none;
   opacity: 0;
   transform: translateX(-20px);
-  transition: visibility 0s .12s linear , opacity .12s ease-in, transform .12s ease-in;
+  transition: opacity .12s ease-in, transform .12s ease-in;
 }
 .content-item.show {
   pointer-events: auto;
   opacity: 1;
   transform: translateX(0);
-  transition: visibility 0s 0s linear , opacity .36s ease-out, transform .36s ease-out;
+  transition: opacity .36s ease-out, transform .36s ease-out;
 }
 
 .wrapper {


### PR DESCRIPTION
I was hacking with @jlord and she told me about this weird issue and I thought CHALLENGE ACCEPTED. 

I was looking for fishy properties that might have an effect on this and disabling them one by one to see if things change, and `visibility` turned out to be the culprit, it seems. As far as I can see the animation still works fine, but obviously @simurai you'd know better. :)

I tried to look from a Chromium bug to back this up, but couldn't find one, and was also unable to reproduce this in a minimum test case so I could file a bug... So here we are. :grimacing:
