### PR TITLE
Don't specify Electron version in packaging scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "lint": "semistandard --verbose | snazzy",
     "test": "mocha tests && npm run lint",
     "sign-win": "signcode -spc ~/electron-api-demos.spc -v ~/electron-api-demos.pvk -a sha1 -$ commercial -n 'Electron API Demos' -i http://electron.atom.io  -t http://timestamp.verisign.com/scripts/timstamp.dll -tr 10 '../EAD-Packages/Electron API Demos-win32-ia32/Electron API Demos.exe'",
-    "pack-mac": "electron-packager . 'Electron API Demos' --platform=darwin --arch=x64 --version=0.36.9 --icon=assets/app-icon/mac/app.icns --prune=true --out='../EAD-Packages' --sign='Developer ID Application: GitHub'",
-    "pack-win": "electron-packager . 'Electron API Demos' --platform=win32 --arch=ia32   --version=0.36.9 --icon=assets/app-icon/win/app.ico --prune=true --out='../EAD-Packages' --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos' && npm run sign-win",
-    "pack-win-win": "electron-packager . Electron API Demos --platform=win32 --arch=ia32   --version=0.36.9 --icon=assets/app-icon/win/app.ico --prune=true --out=EAD-Packages",
-    "pack-lin": "electron-packager . 'Electron API Demos' --platform=linux --arch=x64   --version=0.36.9 --icon=assets/app-icon/png/64.png --prune=true --out='../EAD-Packages'",
+    "pack-mac": "electron-packager . 'Electron API Demos' --platform=darwin --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out='../EAD-Packages' --sign='Developer ID Application: GitHub'",
+    "pack-win": "electron-packager . 'Electron API Demos' --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out='../EAD-Packages' --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos' && npm run sign-win",
+    "pack-win-win": "electron-packager . Electron API Demos --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out=EAD-Packages",
+    "pack-lin": "electron-packager . 'Electron API Demos' --platform=linux --arch=x64 --icon=assets/app-icon/png/64.png --prune=true --out='../EAD-Packages'",
     "package": "npm run pack-mac && npm run pack-win && npm run pack-lin"
   },
   "semistandard": {


### PR DESCRIPTION
Super small PR but I ran into issues with this in Git-it Electron and was thinking we could end up there with this app too—situation: you don't realize you're packaging the app against a much older version of Electron because you forget to update the packaging scripts.

If we ommit the version here then `electron-packager` will use the one specified for `electron-prebuilt`. This way we just have to update that one dependency to keep the app and builds up to date (rather than also having bump the vars in the scripts as well).

🍕 
