### PR TITLE
Remove deprecated BrowserWindow option

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ glob(__dirname + '/main-process/**/*.js', function (error, files) {
 
 function createWindow () {
   var iconPath = path.join(__dirname, '/assets/app-icon/png/512.png')
-  mainWindow = new BrowserWindow({ width: 970, 'min-width': 680, height: 900, icon: iconPath })
+  mainWindow = new BrowserWindow({ width: 970, minWidth: 680, height: 900, icon: iconPath })
   mainWindow.loadURL('file://' + __dirname + '/index.html')
   mainWindow.on('closed', function () {
     mainWindow = null


### PR DESCRIPTION
Simple rename of `min-width` to `minWidth` which is now being properly reported as a deprecated API in the latest Electron release.

/cc @simurai who reported it
