### PR TITLE
Upgrade electron packager and use local out folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+out

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "start": "electron .",
     "lint": "standard-format --write",
     "test": "mocha tests && npm run lint",
-    "sign-win": "signcode -spc ~/electron-api-demos.spc -v ~/electron-api-demos.pvk -a sha1 -$ commercial -n 'Electron API Demos' -i http://electron.atom.io  -t http://timestamp.verisign.com/scripts/timstamp.dll -tr 10 '../EAD-Packages/Electron API Demos-win32-ia32/Electron API Demos.exe'",
-    "pack-mac": "electron-packager . 'Electron API Demos' --platform=darwin --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out='../EAD-Packages' --sign='Developer ID Application: GitHub'",
-    "pack-win": "electron-packager . 'Electron API Demos' --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out='../EAD-Packages' --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos' && npm run sign-win",
-    "pack-win-win": "electron-packager . Electron API Demos --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out=EAD-Packages",
-    "pack-lin": "electron-packager . 'Electron API Demos' --platform=linux --arch=x64 --icon=assets/app-icon/png/64.png --prune=true --out='../EAD-Packages'",
+    "sign-win": "signcode -spc ~/electron-api-demos.spc -v ~/electron-api-demos.pvk -a sha1 -$ commercial -n 'Electron API Demos' -i http://electron.atom.io  -t http://timestamp.verisign.com/scripts/timstamp.dll -tr 10 './out/Electron API Demos-win32-ia32/Electron API Demos.exe'",
+    "pack-mac": "electron-packager . 'Electron API Demos' --overwrite --platform=darwin --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out=out --sign='Developer ID Application: GitHub'",
+    "pack-win": "electron-packager . 'Electron API Demos' --overwrite --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out=out --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos' && npm run sign-win",
+    "pack-win-win": "electron-packager . Electron API Demos --overwrite --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out=out",
+    "pack-lin": "electron-packager . 'Electron API Demos' --overwrite --platform=linux --arch=x64 --icon=assets/app-icon/png/64.png --prune=true --out=out",
     "package": "npm run pack-mac && npm run pack-win && npm run pack-lin"
   },
   "standard": {


### PR DESCRIPTION
This pull request does the following:
- Upgrade to `electron-packager` 6.0 which defaults to ignoring the output folder when packing
- Specify `--overwrite` so successive `pack` calls will work
- Specify the `--out` folder to `out/` so the packaged app sits inside the clone repository instead of as a sibling to the repository.

/cc @jlord @zeke 
