### PR TITLE
Add a outline hack for scrolling issue

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -321,3 +321,16 @@ pre code {
   border-top-right-radius: 3px;
   transform: rotate(-45deg);
 }
+
+/* Hacks --------------------- */
+
+/* Fixes horizontal scrolling in code blocks on OS X El Cap (10.11.3), retina screen
+ *
+ * By adding an invisible outline property, it will force a repaint
+ * which enables the scrolling.
+ */
+
+.hljs:hover,
+.hljs:active {
+  outline: 1px solid transparent;
+}


### PR DESCRIPTION
Following up #76. I'm sitting with @simurai now :sparkles:, we were talking about his new fix that triggers a repaint on code blocks by moving it with 4 different properties, so I mentioned this weird trick @notwaldorf just told me the other day about how `outline` is the one weird trick to force repaint. @simurai and I both got this working on our laptops. Fix coming soon to a computer near you! 

<kbd>Verify challenge</kbd>
