### PR TITLE
Add background color to main-content

### DIFF
--- a/assets/css/content.css
+++ b/assets/css/content.css
@@ -3,7 +3,6 @@
 .main-content {
   visibility: hidden;
   opacity: 0;
-  background-color: #fff;
 }
 
 .main-content.show {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,7 @@ html {
   font-size: 14px;
   line-height: 1.5;
   overflow: hidden; /* Prevents rubber-band scrolling of the whole "page" */
+  background-color: #fff; /* To cover OSes with no default background color */
 }
 
 body {


### PR DESCRIPTION
Tiny PR but wanted to make sure it was ok/got seen.

I tried the app on Windows today and noticed the background was dark and it seemed to me that it was because we don't explicitly give that part of the app a background color, so this PR adds it.

Funny, when you open dev tools the background goes white...

cc @simurai 

![dark-screen](https://cloud.githubusercontent.com/assets/1305617/14336352/bd97521c-fc17-11e5-867f-4b487f2bc402.PNG)
![dev-tools](https://cloud.githubusercontent.com/assets/1305617/14336353/bdb2a044-fc17-11e5-9748-c3b8f41b9d4a.PNG)
