### PR TITLE
Use --osx-sign.identity instead of --sign

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
-    "electron-packager": "^6.0.0",
+    "electron-packager": "^6.0.2",
     "electron-prebuilt": "^0.37.2",
     "mocha": "^2.3.4",
     "spectron": "~1.37.0",


### PR DESCRIPTION
Not sure if `--sign` used to be a thing but signing was not happening via `npm run pack-mac`.

This pull request switches it `--osx-sign.identity` which is what I think we want judging from the `electron-packager` docs.

```
* darwin/mas target platforms only *
osx-sign           (OSX host platform only) Whether to sign the OSX app packages. You can either
                   pass --osx-sign by itself to use the default configuration, or use dot notation
                   to configure a list of sub-properties, e.g. --osx-sign.identity="My Name"

                   Properties supported:
                   - identity: should contain the identity to be used when running `codesign`
                   - entitlements: the path to entitlements used in signing
                   - entitlements-inherit: the path to the 'child' entitlements
```

/cc @jlord @zeke 
