### PR TITLE
tweak the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # electron-api-demos
-This is a desktop app that interactively and with sample code demonstrates core features of the [Electron.js](http://electron.atom.io) API. It's built with Electron, too, of course. This app works on Windows, OS X and Linux operating systems.
 
-Use this app to see what you can do with Electron.js and use the source code to learn how to create a basic Electron app.
+This is a desktop app that interactively and with sample code demonstrates core features of the [Electron](http://electron.atom.io) API. It's built with Electron, too, of course. This app works on Windows, OS X and Linux operating systems.
+
+Use this app to see what you can do with Electron and use the source code to learn how to create a basic Electron app.
 
 ---
 
@@ -16,7 +17,7 @@ announcements. Visit the [electron website](http://electron.atom.io).
 
 You can [download the latest release](https://github.com/atom/electron-api-demos/releases) for your operating system or build it yourself.
 
-### To build
+### To Build
 
 You'll need [Node.js](https://nodejs.org) installed on your computer in order to build this app.
 
@@ -32,7 +33,7 @@ If you don't wish to clone, you can [download the source code](https://github.co
 For easier developing you can launch the app in fullscreen with DevTools open:
 
 ```bash
-$ npm run debug
+$ npm run dev
 ```
 
 #### See the [contributing doc]() on how to contribute.


### PR DESCRIPTION
This is mainly a followup to https://github.com/electron/electron-api-demos/pull/115 that fixes the `npm run dev` command in the README.
