### PR TITLE
Use app.makeSingleInstance

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,10 +15,7 @@ var mainWindow = null
 
 function initialize () {
   var shouldQuit = makeSingleInstance()
-  if (shouldQuit) {
-    app.quit()
-    return
-  }
+  if (shouldQuit) return app.quit()
 
   // Require and setup each JS file in the main-process dir
   glob(path.join(__dirname, 'main-process/**/*.js'), function (error, files) {


### PR DESCRIPTION
This makes it so you can't launch multiple windows on Windows and when you try to launch a second window it un-minimizes and focuses the already open window instead.

http://electron.atom.io/docs/latest/api/app/#appmakesingleinstancecallback
