### PR TITLE
Set textContent instead innerHTML

### DIFF
--- a/sections/communication/ipc.html
+++ b/sections/communication/ipc.html
@@ -83,17 +83,17 @@
       var fs = require('fs');
       // Sync Message
       var syncMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/sync-msg.js');
-      document.getElementById('sync-msg-renderer').innerHTML= syncMsgRendererContent;
+      document.getElementById('sync-msg-renderer').textContent = syncMsgRendererContent;
       var syncMsgMainContent = fs.readFileSync(__dirname + '/main-process/communication/sync-msg.js');
-      document.getElementById('sync-msg-main').innerHTML= syncMsgMainContent;
+      document.getElementById('sync-msg-main').textContent = syncMsgMainContent;
       // Async Message
       var asyncMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/async-msg.js');
-      document.getElementById('async-msg-renderer').innerHTML= asyncMsgRendererContent;
+      document.getElementById('async-msg-renderer').textContent = asyncMsgRendererContent;
       var asyncMsgMainContent = fs.readFileSync(__dirname + '/main-process/communication/async-msg.js');
-      document.getElementById('async-msg-main').innerHTML= asyncMsgMainContent;
+      document.getElementById('async-msg-main').textContent = asyncMsgMainContent;
       // Invisible Window Message
       var invisMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/invisible-msg.js');
-      document.getElementById('invis-msg-renderer').innerHTML= invisMsgRendererContent;
+      document.getElementById('invis-msg-renderer').textContent = invisMsgRendererContent;
       var invisWindowRendererContent = fs.readFileSync(__dirname + '/sections/communication/invisible.html');
       document.getElementById('invis-window-renderer').textContent = invisWindowRendererContent;
     </script>

--- a/sections/menus/menus.html
+++ b/sections/menus/menus.html
@@ -65,10 +65,10 @@
       var fs = require('fs');
       // Application Menu
       var appMenuMainContent = fs.readFileSync(__dirname + '/main-process/menus/application-menu.js');
-      document.getElementById('application-menu-main').innerHTML= appMenuMainContent;
+      document.getElementById('application-menu-main').textContent = appMenuMainContent;
       // Context Menu
       var contextMenuRendererContent = fs.readFileSync(__dirname + '/renderer-process/menus/context-menu.js');
-      document.getElementById('context-menu-renderer').innerHTML= contextMenuRendererContent;
+      document.getElementById('context-menu-renderer').textContent = contextMenuRendererContent;
     </script>
   </section>
 </template>

--- a/sections/native-ui/dialogs.html
+++ b/sections/native-ui/dialogs.html
@@ -116,24 +116,24 @@ ipc.on('open-file-dialog-sheet', function (event) {
       var fs = require('fs')
       // Open File Dialog
       var OpenFileMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/open-file.js')
-      document.getElementById('open-file-main').innerHTML= OpenFileMainContent
+      document.getElementById('open-file-main').textContent = OpenFileMainContent
       var OpenFileRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/open-file.js')
-      document.getElementById('open-file-renderer').innerHTML= OpenFileRendererContent
+      document.getElementById('open-file-renderer').textContent = OpenFileRendererContent
       // Error Dialog
       var ErrorMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/error.js')
-      document.getElementById('error-dialog-main').innerHTML= ErrorMainContent
+      document.getElementById('error-dialog-main').textContent = ErrorMainContent
       var ErrorRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/error.js')
-      document.getElementById('error-dialog-renderer').innerHTML= ErrorRendererContent
+      document.getElementById('error-dialog-renderer').textContent = ErrorRendererContent
       // Information Dialog
       var InfoMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/information.js')
-      document.getElementById('information-dialog-main').innerHTML= InfoMainContent
+      document.getElementById('information-dialog-main').textContent = InfoMainContent
       var InfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/information.js')
-      document.getElementById('information-dialog-renderer').innerHTML= InfoRendererContent
+      document.getElementById('information-dialog-renderer').textContent = InfoRendererContent
       // Save Dialog
       var SaveMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/save.js')
-      document.getElementById('save-dialog-main').innerHTML= SaveMainContent
+      document.getElementById('save-dialog-main').textContent = SaveMainContent
       var SaveRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/save.js')
-      document.getElementById('save-dialog-renderer').innerHTML= SaveRendererContent
+      document.getElementById('save-dialog-renderer').textContent = SaveRendererContent
     </script>
   </section>
 </template>

--- a/sections/native-ui/ex-links-file-manager.html
+++ b/sections/native-ui/ex-links-file-manager.html
@@ -62,13 +62,13 @@
       var fs = require('fs');
       // Open File Manager
       var openFileManagerRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/ex-links-file-manager/file-manager.js');
-      document.getElementById('file-manager-renderer').innerHTML= openFileManagerRendererContent;
+      document.getElementById('file-manager-renderer').textContent = openFileManagerRendererContent;
       // Open External Links
       var exLinksRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/ex-links-file-manager/ex-links.js');
-      document.getElementById('ex-links-renderer').innerHTML= exLinksRendererContent;
+      document.getElementById('ex-links-renderer').textContent = exLinksRendererContent;
       // Open All External Links
       var AllExLinksRendererContent = fs.readFileSync(__dirname + '/assets/ex-links.js');
-      document.getElementById('all-ex-links-renderer').innerHTML= AllExLinksRendererContent;
+      document.getElementById('all-ex-links-renderer').textContent = AllExLinksRendererContent;
     </script>
   </section>
 </template>

--- a/sections/native-ui/tray.html
+++ b/sections/native-ui/tray.html
@@ -46,9 +46,9 @@
       var fs = require('fs');
       // Put in Tray
       var trayRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/tray/tray.js');
-      document.getElementById('tray-renderer').innerHTML= trayRendererContent;
+      document.getElementById('tray-renderer').textContent = trayRendererContent;
       var trayMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/tray/tray.js');
-      document.getElementById('tray-main').innerHTML= trayMainContent;
+      document.getElementById('tray-main').textContent = trayMainContent;
     </script>
   </section>
 </template>

--- a/sections/printing/pdf.html
+++ b/sections/printing/pdf.html
@@ -45,12 +45,12 @@
       var fs = require('fs');
       // Open File Dialog
       var printPDFRendererContent = fs.readFileSync(__dirname + '/renderer-process/printing/pdf.js');
-      document.getElementById('print-pdf-renderer').innerHTML= printPDFRendererContent;
+      document.getElementById('print-pdf-renderer').textContent = printPDFRendererContent;
       var printPDFMainContent = fs.readFileSync(__dirname + '/main-process/printing/pdf.js');
-      document.getElementById('print-pdf-main').innerHTML= printPDFMainContent;
+      document.getElementById('print-pdf-main').textContent = printPDFMainContent;
       // Print Style Sheet
       var printStyleSheet = fs.readFileSync(__dirname + '/assets/css/print.css');
-      document.getElementById('print-style-sheet').innerHTML= printStyleSheet;
+      document.getElementById('print-style-sheet').textContent = printStyleSheet;
     </script>
   </section>
 </tempalte>

--- a/sections/system/app-sys-information.html
+++ b/sections/system/app-sys-information.html
@@ -89,13 +89,13 @@ process.versions.node</code></pre>
       var fs = require('fs')
       // App Information
       var appInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/app-information.js')
-      document.getElementById('app-info-renderer').innerHTML= appInfoRendererContent
+      document.getElementById('app-info-renderer').textContent = appInfoRendererContent
       // Sys Information
       var sysInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/sys-information.js')
-      document.getElementById('sys-info-renderer').innerHTML= sysInfoRendererContent
+      document.getElementById('sys-info-renderer').textContent = sysInfoRendererContent
       // Screen Information
       var screenInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/screen-information.js')
-      document.getElementById('screen-info-renderer').innerHTML= screenInfoRendererContent
+      document.getElementById('screen-info-renderer').textContent = screenInfoRendererContent
     </script>
   </section>
 </template>

--- a/sections/system/clipboard.html
+++ b/sections/system/clipboard.html
@@ -55,10 +55,10 @@
       var fs = require('fs');
       // Copy
       var copyToRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/copy.js');
-      document.getElementById('copy-to-renderer').innerHTML= copyToRendererContent;
+      document.getElementById('copy-to-renderer').textContent = copyToRendererContent;
       // Paste
       var pasteToRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/paste.js');
-      document.getElementById('paste-to-renderer').innerHTML= pasteToRendererContent;
+      document.getElementById('paste-to-renderer').textContent = pasteToRendererContent;
     </script>
   </section>
 </tempalte>

--- a/sections/windows/windows.html
+++ b/sections/windows/windows.html
@@ -103,13 +103,13 @@
       var fs = require('fs');
       // New Window
       var windowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/create-window.js');
-      document.getElementById('new-window-renderer').innerHTML= windowRendererContent;
+      document.getElementById('new-window-renderer').textContent = windowRendererContent;
       // Manage Window
       var manageWindowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/manage-window.js');
-      document.getElementById('manage-window-renderer').innerHTML= manageWindowRendererContent;
+      document.getElementById('manage-window-renderer').textContent = manageWindowRendererContent;
       // Frameless Window
       var framelessWindowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/frameless-window.js');
-      document.getElementById('frameless-window-renderer').innerHTML= framelessWindowRendererContent;
+      document.getElementById('frameless-window-renderer').textContent = framelessWindowRendererContent;
     </script>
   </section>
 </template>


### PR DESCRIPTION
`innerHTML` supports HTML but for all the code blocks we expect them to be just code so don't actually parse the content as HTML and instead use `textContent`.

/cc @jlord @zeke 
