### PR TITLE
Add helper to fill in code blocks

### DIFF
--- a/assets/code-blocks.js
+++ b/assets/code-blocks.js
@@ -1,0 +1,7 @@
+var fs = require('fs')
+var path = require('path')
+
+var codeBlocks = document.querySelectorAll('code[data-path]')
+Array.prototype.forEach.call(codeBlocks, function (code) {
+  code.textContent = fs.readFileSync(path.join(__dirname, code.dataset.path))
+})

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
   <script src="assets/ex-links.js"></script>
   <script src="assets/nav.js"></script>
   <script src="assets/demo-btns.js"></script>
+  <script src="assets/code-blocks.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
 
 </body>

--- a/sections/communication/ipc.html
+++ b/sections/communication/ipc.html
@@ -27,9 +27,9 @@
 
           <p>This example sends a "ping" from this process (renderer) to the main process. The main process then replies with "pong".</p>
           <h5>Renderer Process</h5>
-          <pre><code id="async-msg-renderer"></pre></code>
+          <pre><code data-path="renderer-process/communication/async-msg.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="async-msg-main"></code></pre>
+          <pre><code data-path="main-process/communication/async-msg.js"></code></pre>
         </div>
       </div>
     </div>
@@ -47,9 +47,9 @@
           <p>You can use the <code>ipc</code> module to send synchronous messages between processes as well, but note that the synchronous nature of this method means that it <b>will block</b> other operations while completing its task.</p>
           <p>This example sends a synchronous message, "ping", from this process (renderer) to the main process. The main process then replies with "pong".</p>
           <h5>Renderer Process</h5>
-          <pre><code id="sync-msg-renderer"></pre></code>
+          <pre><code data-path="renderer-process/communication/sync-msg.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="sync-msg-main"></code></pre>
+          <pre><code data-path="main-process/communication/sync-msg.js"></code></pre>
         </div>
       </div>
     </div>
@@ -68,9 +68,9 @@
           <p>In this example we use the <code>remote</code> module to create a new invisible browser window from this renderer process. When the new page is loaded we send a message with <code>ipc</code> that the new window is listening for.</p>
           <p>The new window then computes the factorial and sends the result to be recieved by this, the original, window and added to the page above.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="invis-msg-renderer"></pre></code>
+          <pre><code data-path="renderer-process/communication/invisible-msg.js"></pre></code>
           <h5>Invisible Window Page HTML</h5>
-          <pre><code id="invis-window-renderer"></code></pre>
+          <pre><code data-path="sections/communication/invisible.html"></code></pre>
         </div>
       </div>
     </div>
@@ -79,23 +79,5 @@
     <script type="text/javascript" src="renderer-process/communication/async-msg.js"></script>
     <script type="text/javascript" src="renderer-process/communication/invisible-msg.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Sync Message
-      var syncMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/sync-msg.js');
-      document.getElementById('sync-msg-renderer').textContent = syncMsgRendererContent;
-      var syncMsgMainContent = fs.readFileSync(__dirname + '/main-process/communication/sync-msg.js');
-      document.getElementById('sync-msg-main').textContent = syncMsgMainContent;
-      // Async Message
-      var asyncMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/async-msg.js');
-      document.getElementById('async-msg-renderer').textContent = asyncMsgRendererContent;
-      var asyncMsgMainContent = fs.readFileSync(__dirname + '/main-process/communication/async-msg.js');
-      document.getElementById('async-msg-main').textContent = asyncMsgMainContent;
-      // Invisible Window Message
-      var invisMsgRendererContent = fs.readFileSync(__dirname + '/renderer-process/communication/invisible-msg.js');
-      document.getElementById('invis-msg-renderer').textContent = invisMsgRendererContent;
-      var invisWindowRendererContent = fs.readFileSync(__dirname + '/sections/communication/invisible.html');
-      document.getElementById('invis-window-renderer').textContent = invisWindowRendererContent;
-    </script>
   </section>
 </template>

--- a/sections/menus/menus.html
+++ b/sections/menus/menus.html
@@ -24,7 +24,7 @@
 
           <p>This app uses the code below to set the application menu. If you click the 'View' option in the application menu and then the 'App Menu Demo', you'll see an information box displayed.</p>
           <h5>Main Process</h5>
-          <pre><code id="application-menu-main"></code></pre>
+          <pre><code data-path="main-process/menus/application-menu.js"></code></pre>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
@@ -54,21 +54,12 @@
 
           <p>In this demo we use the <code>remote</code> module to access <code>menu</code> and <code>menuitem</code> from the renderer process.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="context-menu-renderer"></pre></code>
+          <pre><code data-path="renderer-process/menus/context-menu.js"></pre></code>
         </div>
       </div>
     </div>
 
     <script type="text/javascript" src="renderer-process/menus/context-menu.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Application Menu
-      var appMenuMainContent = fs.readFileSync(__dirname + '/main-process/menus/application-menu.js');
-      document.getElementById('application-menu-main').textContent = appMenuMainContent;
-      // Context Menu
-      var contextMenuRendererContent = fs.readFileSync(__dirname + '/renderer-process/menus/context-menu.js');
-      document.getElementById('context-menu-renderer').textContent = contextMenuRendererContent;
-    </script>
   </section>
 </template>

--- a/sections/native-ui/dialogs.html
+++ b/sections/native-ui/dialogs.html
@@ -26,9 +26,9 @@
           </div>
           <p>In this demo, the <code>ipc</code> module is used to send a message from the renderer process instructing the main process to launch the open file (or directory) dialog. If a file is selected, the main process can send that information back to the renderer process.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="open-file-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/dialogs/open-file.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="open-file-main"></code></pre>
+          <pre><code data-path="main-process/native-ui/dialogs/open-file.js"></code></pre>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
@@ -60,9 +60,9 @@ ipc.on('open-file-dialog-sheet', function (event) {
 
           <p>You can use an error dialog before the app's <code>ready</code> event, which is useful for showing errors upon startup.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="error-dialog-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/dialogs/error.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="error-dialog-main"></code></pre>
+          <pre><code data-path="main-process/native-ui/dialogs/error.js"></code></pre>
         </div>
       </div>
     </div>
@@ -81,9 +81,9 @@ ipc.on('open-file-dialog-sheet', function (event) {
 
           <p>An information dialog can contain an icon, your choice of buttons, title and message.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="information-dialog-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/dialogs/information.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="information-dialog-main"></code></pre>
+          <pre><code data-path="main-process/native-ui/dialogs/information.js"></code></pre>
         </div>
       </div>
     </div>
@@ -100,9 +100,9 @@ ipc.on('open-file-dialog-sheet', function (event) {
           </div>
           <p>In this demo, the <code>ipc</code> module is used to send a message from the renderer process instructing the main process to launch the save dialog. It returns the path selected by the user which can be relayed back to the renderer process.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="save-dialog-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/dialogs/save.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="save-dialog-main"></code></pre>
+          <pre><code data-path="main-process/native-ui/dialogs/save.js"></code></pre>
         </div>
       </div>
     </div>
@@ -112,28 +112,5 @@ ipc.on('open-file-dialog-sheet', function (event) {
     <script type="text/javascript" src="renderer-process/native-ui/dialogs/information.js"></script>
     <script type="text/javascript" src="renderer-process/native-ui/dialogs/save.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs')
-      // Open File Dialog
-      var OpenFileMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/open-file.js')
-      document.getElementById('open-file-main').textContent = OpenFileMainContent
-      var OpenFileRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/open-file.js')
-      document.getElementById('open-file-renderer').textContent = OpenFileRendererContent
-      // Error Dialog
-      var ErrorMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/error.js')
-      document.getElementById('error-dialog-main').textContent = ErrorMainContent
-      var ErrorRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/error.js')
-      document.getElementById('error-dialog-renderer').textContent = ErrorRendererContent
-      // Information Dialog
-      var InfoMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/information.js')
-      document.getElementById('information-dialog-main').textContent = InfoMainContent
-      var InfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/information.js')
-      document.getElementById('information-dialog-renderer').textContent = InfoRendererContent
-      // Save Dialog
-      var SaveMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/dialogs/save.js')
-      document.getElementById('save-dialog-main').textContent = SaveMainContent
-      var SaveRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/dialogs/save.js')
-      document.getElementById('save-dialog-renderer').textContent = SaveRendererContent
-    </script>
   </section>
 </template>

--- a/sections/native-ui/ex-links-file-manager.html
+++ b/sections/native-ui/ex-links-file-manager.html
@@ -25,7 +25,7 @@
           <p>This demonstrates using the <code>shell</code> module to open the system file manager at a particular location.</p>
           <p>Clicking the demo button will open your file manager at the root.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="file-manager-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/ex-links-file-manager/file-manager.js"></pre></code>
         </div>
       </div>
     </div>
@@ -42,14 +42,14 @@
           <p>If you do not want your app to open website links <em>within</em> the app, you can use the <code>shell</code> module to open them externally. When clicked, the links will open outside of your app and in the user's default web browser.</p>
           <p>When the demo button is clicked, the electron website will open in your browser.<p>
           <h5>Renderer Process</h5>
-          <pre><code id="ex-links-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/ex-links-file-manager/ex-links.js"></pre></code>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
             <strong>Open all outbound links externally.</strong>
             <p>You may want to open all <code>http</code> and <code>https</code> links outside of your app. To do this, query the document and loop through each link and add a listener. This app uses the code below which is located in <code>assets/ex-links.js</code>.</h5>
             <h5>Renderer Process</h5>
-            <pre><code id="all-ex-links-renderer"></pre></code>
+            <pre><code data-path="assets/ex-links.js"></pre></code>
           </div>
         </div>
       </div>
@@ -58,17 +58,5 @@
     <script type="text/javascript" src="renderer-process/native-ui/ex-links-file-manager/file-manager.js"></script>
     <script type="text/javascript" src="renderer-process/native-ui/ex-links-file-manager/ex-links.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Open File Manager
-      var openFileManagerRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/ex-links-file-manager/file-manager.js');
-      document.getElementById('file-manager-renderer').textContent = openFileManagerRendererContent;
-      // Open External Links
-      var exLinksRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/ex-links-file-manager/ex-links.js');
-      document.getElementById('ex-links-renderer').textContent = exLinksRendererContent;
-      // Open All External Links
-      var AllExLinksRendererContent = fs.readFileSync(__dirname + '/assets/ex-links.js');
-      document.getElementById('all-ex-links-renderer').textContent = AllExLinksRendererContent;
-    </script>
   </section>
 </template>

--- a/sections/native-ui/tray.html
+++ b/sections/native-ui/tray.html
@@ -27,9 +27,9 @@
 
           <p>In this example the tray icon can be removed by clicking 'Remove' in the context menu or selecting the demo button again.</p>
           <h5>Main Process</h5>
-          <pre><code id="tray-main"></pre></code>
+          <pre><code data-path="main-process/native-ui/tray/tray.js"></pre></code>
           <h5>Renderer Process</h5>
-          <pre><code id="tray-renderer"></pre></code>
+          <pre><code data-path="renderer-process/native-ui/tray/tray.js"></pre></code>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
@@ -42,13 +42,5 @@
 
     <script type="text/javascript" src="renderer-process/native-ui/tray/tray.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Put in Tray
-      var trayRendererContent = fs.readFileSync(__dirname + '/renderer-process/native-ui/tray/tray.js');
-      document.getElementById('tray-renderer').textContent = trayRendererContent;
-      var trayMainContent = fs.readFileSync(__dirname + '/main-process/native-ui/tray/tray.js');
-      document.getElementById('tray-main').textContent = trayMainContent;
-    </script>
   </section>
 </template>

--- a/sections/printing/pdf.html
+++ b/sections/printing/pdf.html
@@ -25,15 +25,15 @@
           <p>To demonstrate the print to PDF functionality, the demo button above will save this page as a PDF and, if you have a PDF viewer, open the file.</p>
           <p>In a real-world application you're more likely to add this to application menu, but for the purposes of the demo we've set it to the demo button.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="print-pdf-renderer"></pre></code>
+          <pre><code data-path="renderer-process/printing/pdf.js"></pre></code>
           <h5>Main Process</h5>
-          <pre><code id="print-pdf-main"></code></pre>
+          <pre><code data-path="main-process/printing/pdf.js"></code></pre>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
             <strong>Use a print style sheet.</strong>
             <p>You can create a stylesheet targeting printing to optimize the look of what your users print. Below is the stylesheet used in this app, located in <code>assets/css/print.css</code>.</p>
-            <pre><code id="print-style-sheet"></code></pre>
+            <pre><code data-path="assets/css/print.css"></code></pre>
           </div>
         </div>
       </div>
@@ -41,16 +41,5 @@
 
     <script type="text/javascript" src="renderer-process/printing/pdf.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Open File Dialog
-      var printPDFRendererContent = fs.readFileSync(__dirname + '/renderer-process/printing/pdf.js');
-      document.getElementById('print-pdf-renderer').textContent = printPDFRendererContent;
-      var printPDFMainContent = fs.readFileSync(__dirname + '/main-process/printing/pdf.js');
-      document.getElementById('print-pdf-main').textContent = printPDFMainContent;
-      // Print Style Sheet
-      var printStyleSheet = fs.readFileSync(__dirname + '/assets/css/print.css');
-      document.getElementById('print-style-sheet').textContent = printStyleSheet;
-    </script>
   </section>
 </tempalte>

--- a/sections/system/app-sys-information.html
+++ b/sections/system/app-sys-information.html
@@ -25,7 +25,7 @@
           <p>The example below gets the version of Electron in use by the app.</p>
           <p>See the <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/process">process documentation</a> for more.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="app-info-renderer"></pre></code>
+          <pre><code data-path="renderer-process/system/app-information.js"></pre></code>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
@@ -57,7 +57,7 @@ process.versions.node</code></pre>
 
           <p>See the full <a class="u-exlink" href="https://nodejs.org/api/os.html"> os documentation</a> for more.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="sys-info-renderer"></pre></code>
+          <pre><code data-path="renderer-process/system/sys-information.js"></pre></code>
         </div>
       </div>
     </div>
@@ -76,7 +76,7 @@ process.versions.node</code></pre>
 
           <p>See the full <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/screen">screen documentation</a> for more.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="screen-info-renderer"></pre></code>
+          <pre><code data-path="renderer-process/system/screen-information.js"></pre></code>
         </div>
       </div>
     </div>
@@ -85,17 +85,5 @@ process.versions.node</code></pre>
     <script type="text/javascript" src="renderer-process/system/sys-information.js"></script>
     <script type="text/javascript" src="renderer-process/system/screen-information.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs')
-      // App Information
-      var appInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/app-information.js')
-      document.getElementById('app-info-renderer').textContent = appInfoRendererContent
-      // Sys Information
-      var sysInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/sys-information.js')
-      document.getElementById('sys-info-renderer').textContent = sysInfoRendererContent
-      // Screen Information
-      var screenInfoRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/screen-information.js')
-      document.getElementById('screen-info-renderer').textContent = screenInfoRendererContent
-    </script>
   </section>
 </template>

--- a/sections/system/clipboard.html
+++ b/sections/system/clipboard.html
@@ -25,7 +25,7 @@
           </div>
           <p>In this example we copy a phrase to the clipboard. After clicking 'Copy' use the text area to paste (CMD + V or CTRL + V) the phrase from the clipboard.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="copy-to-renderer"></pre></code>
+          <pre><code data-path="renderer-process/system/copy.js"></pre></code>
         </div>
       </div>
     </div>
@@ -43,7 +43,7 @@
           <p>In this example we copy a string to the clipboard and then paste the results into a message above.</p>
 
           <h5>Renderer Process</h5>
-          <pre><code id="paste-to-renderer"></pre></code>
+          <pre><code data-path="renderer-process/system/paste.js"></pre></code>
         </div>
       </div>
     </div>
@@ -51,14 +51,5 @@
     <script type="text/javascript" src="renderer-process/system/copy.js"></script>
     <script type="text/javascript" src="renderer-process/system/paste.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // Copy
-      var copyToRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/copy.js');
-      document.getElementById('copy-to-renderer').textContent = copyToRendererContent;
-      // Paste
-      var pasteToRendererContent = fs.readFileSync(__dirname + '/renderer-process/system/paste.js');
-      document.getElementById('paste-to-renderer').textContent = pasteToRendererContent;
-    </script>
   </section>
 </tempalte>

--- a/sections/windows/windows.html
+++ b/sections/windows/windows.html
@@ -27,7 +27,7 @@
 
           <p>There are a lot of options when creating a new window. A few are in this demo, but visit the <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/browser-window">documentation</a> for the full list.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="new-window-renderer"></pre></code>
+          <pre><code data-path="renderer-process/windows/create-window.js"></pre></code>
 
           <div class="demo-protip">
             <h2>ProTip</h2>
@@ -56,7 +56,7 @@
 
           <p>There are a lot of methods for controlling the state of the window such as the size, location, and focus status as well as events to listen to for window changes. Visit the <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/browser-windows">documentation</a> for the full list.</p>
           <h5>Renderer Process</h5>
-          <pre><code id="manage-window-renderer"></pre></code>
+          <pre><code data-path="renderer-process/windows/manage-window.js"></pre></code>
         </div>
       </div>
     </div>
@@ -77,7 +77,7 @@
           </p>
 
           <h5>Renderer Process</h5>
-          <pre><code id="frameless-window-renderer"></pre></code>
+          <pre><code data-path="renderer-process/windows/frameless-window.js"></pre></code>
 
           <p>Windows can have a transparent background, too. By setting the <code>transparent</code> option to <code>true</code>, you can also make your frameless window transparent:</p>
           <pre>
@@ -99,17 +99,5 @@
     <script type="text/javascript" src="renderer-process/windows/manage-window.js"></script>
     <script type="text/javascript" src="renderer-process/windows/frameless-window.js"></script>
 
-    <script type="text/javascript">
-      var fs = require('fs');
-      // New Window
-      var windowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/create-window.js');
-      document.getElementById('new-window-renderer').textContent = windowRendererContent;
-      // Manage Window
-      var manageWindowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/manage-window.js');
-      document.getElementById('manage-window-renderer').textContent = manageWindowRendererContent;
-      // Frameless Window
-      var framelessWindowRendererContent = fs.readFileSync(__dirname + '/renderer-process/windows/frameless-window.js');
-      document.getElementById('frameless-window-renderer').textContent = framelessWindowRendererContent;
-    </script>
   </section>
 </template>


### PR DESCRIPTION
Adds a helper that processes all `<code>` blocks with a `data-path` attribute and fill them with the content at the path specified.

This removes the need for a `<script>` tag in each example that reads content from disk and sets the `textContent` of the element by id.

/cc @jlord @zeke 
