### PR TITLE
Use productName in data path

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -18,7 +18,8 @@ describe('demo app', function () {
   var app
 
   var removeStoredPreferences = function () {
-    var userDataPath = path.join(process.env.HOME, 'Library', 'Application Support', 'electron-api-demos')
+    var productName = require('../package').productName
+    var userDataPath = path.join(process.env.HOME, 'Library', 'Application Support', productName)
     try {
       fs.unlinkSync(path.join(userDataPath, 'activeDemoButtonId.json'))
     } catch (error) {


### PR DESCRIPTION
Currently the specs are failing on master because the state directory changed by adding `productName` to `package.json` as part of #119

This updates the spec helper to use `productName` in the specs directly.
