### PR TITLE
Add prepare-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "dev": "electron . --debug",
     "lint": "standard",
     "test": "mocha tests && npm run lint",
-    "sign-win-exe": "./script/sign-exe.sh",
-    "sign-win-installer": "./script/sign-installer.sh",
+    "sign-exe": "./script/sign-exe.sh",
+    "sign-installer": "./script/sign-installer.sh",
     "pack-mac": "electron-packager . --asar --overwrite --platform=darwin --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out=out --osx-sign.identity='Developer ID Application: GitHub'",
     "pack-win": "electron-packager . ElectronAPIDemos --asar  --overwrite --platform=win32 --arch=ia32 --icon=assets/app-icon/win/app.ico --prune=true --out=out --version-string.CompanyName='GitHub, Inc.' --version-string.FileDescription='Electron API Demos' --version-string.ProductName='Electron API Demos'",
-    "pack-lin": "electron-packager . --asar --overwrite --platform=linux --arch=x64 --icon=assets/app-icon/png/64.png --prune=true --out=out",
-    "package": "npm run pack-mac && npm run pack-win && npm run pack-lin && npm run installer",
+    "pack-linux": "electron-packager . --asar --overwrite --platform=linux --arch=x64 --icon=assets/app-icon/png/64.png --prune=true --out=out",
+    "package": "npm run pack-mac && npm run pack-win && npm run pack-linux",
     "installer": "node ./script/installer.js",
+    "prepare-release": "npm run package && npm run sign-exe && npm run installer && npm run sign-installer",
     "release": "node ./script/release.js"
   },
   "standard": {


### PR DESCRIPTION
This script will do the following:
- Package the app on all platforms
- Sign the Windows exe
- Build a Windows installer
- Sign the Windows installer

I created this as a separate script than `package` since often signing and creating the installer is not needed to test on Windows and takes a bit of time.

So now releasing can be accomplished with:

``` sh
npm run prepare-release && npm run release
```
