### PR TITLE
Only set window icon on Linux

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,8 +27,16 @@ function initialize () {
   })
 
   function createWindow () {
-    var iconPath = path.join(__dirname, '/assets/app-icon/png/512.png')
-    mainWindow = new BrowserWindow({ width: 1080, minWidth: 680, height: 800, icon: iconPath })
+    var windowOptions = {
+      width: 1080,
+      minWidth: 680,
+      height: 800
+    }
+    if (process.platform === 'linux') {
+      windowOptions.icon = path.join(__dirname, '/assets/app-icon/png/512.png')
+    }
+
+    mainWindow = new BrowserWindow(windowOptions)
     mainWindow.loadURL(path.join('file://', __dirname, '/index.html'))
 
     // Launch fullscreen with DevTools open, usage: npm run debug


### PR DESCRIPTION
I believe this fixes the icon pixelation on Windows.

See https://github.com/atom/atom/blob/e230841b57f13607ec6f38d8576b2ddf3dfa7315/src/browser/atom-window.coffee#L33-L36 for prior art.

:tophat: Hat tip to @simurai for mentioning this in https://github.com/electron/electron-api-demos/issues/53#issuecomment-208570534
### Before

<img width="265" alt="screen shot 2016-04-14 at 9 25 24 am" src="https://cloud.githubusercontent.com/assets/671378/14535469/dab65c74-0222-11e6-849a-fda80eb60139.png">
### After

<img width="263" alt="screen shot 2016-04-14 at 9 24 29 am" src="https://cloud.githubusercontent.com/assets/671378/14535468/dab5f0e0-0222-11e6-86ef-e46183f6238f.png">

Refs #53
