### PR TITLE
add missing links to intro page

### DIFF
--- a/sections/about.html
+++ b/sections/about.html
@@ -7,7 +7,7 @@
       <main class="about-sections">
         <section class="about-section play-along">
           <h2>Play Along</h2>
-            <p>Use the demo snippets in an Electron app of your own. The <a href="" class="u-exlink">Electron Quick Start</a> app is a bare-bones setup that pairs with these demos. Follow the instructions here to get it going. You'll need <a href="" class="u-exlink">Git</a> and <a href="" class="u-exlink">Node.js</a> on your computer to do this.</p>
+            <p>Use the demo snippets in an Electron app of your own. The <a href="https://github.com/electron/electron-quick-start" class="u-exlink">Electron Quick Start</a> app is a bare-bones setup that pairs with these demos. Follow the instructions here to get it going. You'll need <a href="https://desktop.github.com/" class="u-exlink">Git</a> and <a href="https://nodejs.org/" class="u-exlink">Node.js</a> on your computer to do this.</p>
 <pre><code>$ git clone https://github.com/atom/electron-quick-start
 $ cd electron-quick-start
 $ npm install && npm start
@@ -15,9 +15,9 @@ $ npm install && npm start
         </section>
         <section class="about-section about-code">
           <h2>About the Code</h2>
-            <p>The <a href="" class="u-exlink">source code of this app</a> has been organized with ease of navigation in mind.</p>
+            <p>The <a href="https://github.com/electron/electron-api-demos" class="u-exlink">source code of this app</a> has been organized with ease of navigation in mind.</p>
 
-            <p>Nearly all (over 90%) of <a href="" class="u-exlink">ES2015</a> is availble to use in Electron <em>without the use of pre-processors</em> because it's a part of <a href="" class="u-exlink">V8</a> which is built into Electron.</p>
+            <p>Nearly all (over 90%) of <a href="http://babeljs.io/docs/learn-es2015/" class="u-exlink">ES2015</a> is availble to use in Electron <em>without the use of pre-processors</em> because it's a part of <a href="https://developers.google.com/v8/" class="u-exlink">V8</a> which is built into Electron.</p>
 
             <p>To illustrate this we've made use of <code>const</code>, for un changing declarations; <code>let</code> for scoped declarations; and template strings like: <code>`Result is ${output}`</code> in the demo snippets.</p>
         </section>


### PR DESCRIPTION
I just noticed that none of the `<a>` tags on the intro page had `hrefs`. This PR fills 'em in.

@jlord 
