### PR TITLE
Add version to update url

### DIFF
--- a/auto-updater.js
+++ b/auto-updater.js
@@ -1,3 +1,4 @@
+const app = require('electron').app
 const autoUpdater = require('electron').autoUpdater
 const Menu = require('electron').Menu
 
@@ -29,7 +30,7 @@ exports.initialize = function () {
     exports.updateMenu()
   })
 
-  autoUpdater.setFeedURL('https://electron-api-demos.githubapp.com/updates')
+  autoUpdater.setFeedURL(`https://electron-api-demos.githubapp.com/updates?version=${app.getVersion()}`)
   autoUpdater.checkForUpdates()
 }
 


### PR DESCRIPTION
I deployed `0.2.0` this morning and verified an update from `0.1.0`.

This pull request adds the version to the update URL so updates will only occur when people are not on the latest version.
