### PR TITLE
Check if section exists before clicking

### DIFF
--- a/assets/nav.js
+++ b/assets/nav.js
@@ -6,7 +6,8 @@ storage.get('activeSectionButtonId', function (err, id) {
 
   if (id && id.length) {
     showMainContent()
-    document.getElementById(id).click()
+    var section = document.getElementById(id)
+    if (section) section.click()
   } else {
     activateDefaultSection()
     displayAbout()


### PR DESCRIPTION
If you switch between branches with different sections then previously you might see the following error when starting the demo app:

```
Uncaught TypeError: Cannot read property 'click' of null
```

This is because the persisted section id might not be present in the now running app.

This pull request adds a guard to only click sections if they exist.

This might come in handy in the future if we ship an update with different ids and the last persisted id is no longer in the app.
