### PR TITLE
Add note about Information Dialog Titles

### DIFF
--- a/sections/native-ui/dialogs.html
+++ b/sections/native-ui/dialogs.html
@@ -79,7 +79,7 @@ ipc.on('open-file-dialog-sheet', function (event) {
           </div>
           <p>In this demo, the <code>ipc</code> module is used to send a message from the renderer process instructing the main process to launch the information dialog. Options may be provided for responses which can then be relayed back to the renderer process.</p>
 
-          <p>Note: The `title` property is not displayed in OS X.</p>
+          <p>Note: The <code>title</code> property is not displayed in OS X.</p>
 
           <p>An information dialog can contain an icon, your choice of buttons, title and message.</p>
           <h5>Renderer Process</h5>


### PR DESCRIPTION
Adding a note in the Information Dialog demo to say that the 'title' property isn't displayed on OS X. 

It's WIP because when I get back on desktop I just want to verify that it does show up on Windows.
