### PR TITLE
Upgrade electron and electron-packager

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
-    "electron-packager": "^7.0.0",
+    "electron-packager": "^7.0.1",
     "electron-prebuilt": "^0.37.7",
     "electron-winstaller": "^2.2.0",
     "mocha": "^2.3.4",


### PR DESCRIPTION
- Upgrade to Electron 0.37.7
- Upgrade packager for ssl warning fix https://github.com/electron-userland/electron-packager/releases/tag/v7.0.1
