### PR TITLE
Update repository URL references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ announcements. Visit the [electron website](http://electron.atom.io).
 
 ## Using
 
-You can [download the latest release](https://github.com/atom/electron-api-demos/releases) for your operating system or build it yourself (see below).
+You can [download the latest release](https://github.com/electron/electron-api-demos/releases) for your operating system or build it yourself (see below).
 
 ## Building
 
 You'll need [Node.js](https://nodejs.org) installed on your computer in order to build this app.
 
 ```bash
-$ git clone https://github.com/atom/electron-api-demos
+$ git clone https://github.com/electron/electron-api-demos
 $ cd electron-api-demos
 $ npm install
 $ npm start
 ```
 
-If you don't wish to clone, you can [download the source code](https://github.com/atom/electron-api-demos/archive/master.zip).
+If you don't wish to clone, you can [download the source code](https://github.com/electron/electron-api-demos/archive/master.zip).
 
 For easier developing you can launch the app in fullscreen with DevTools open:
 


### PR DESCRIPTION
looks like this repo was moved from the atom org to electron 😄 