### PR TITLE
fix broken link to global shortcut api

### DIFF
--- a/sections/menus/shortcuts.html
+++ b/sections/menus/shortcuts.html
@@ -21,7 +21,7 @@
           <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/menu">Menu</a>,
           <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/accelerator">Accelerator</a>,
           and
-          <a class="u-exlink" href="http://electron.atom.io/docs/latest/api/globalShorcut">globalShortcut</a>
+          <a class="u-exlink" href="http://electron.atom.io/docs/api/global-shortcut">globalShortcut</a>
           APIs in your browser.
         </p>
 


### PR DESCRIPTION
The page wasn't found anymore and the redirect didn't work.