### PR TITLE
Use different shortcut keybinding

### DIFF
--- a/main-process/menus/shortcuts.js
+++ b/main-process/menus/shortcuts.js
@@ -4,7 +4,7 @@ const dialog = electron.dialog
 const globalShortcut = electron.globalShortcut
 
 app.on('ready', function () {
-  globalShortcut.register('CommandOrControl+Alt+D', function () {
+  globalShortcut.register('CommandOrControl+Alt+K', function () {
     dialog.showMessageBox({
       type: 'info',
       message: 'Success! You pressed the registered global shortcut keybinding.',

--- a/main-process/menus/shortcuts.js
+++ b/main-process/menus/shortcuts.js
@@ -7,7 +7,8 @@ app.on('ready', function () {
   globalShortcut.register('CommandOrControl+Alt+K', function () {
     dialog.showMessageBox({
       type: 'info',
-      message: 'Success! You pressed the registered global shortcut keybinding.',
+      message: 'Success!',
+      detail: 'You pressed the registered global shortcut keybinding.',
       buttons: ['Yay']
     })
   })

--- a/main-process/menus/shortcuts.js
+++ b/main-process/menus/shortcuts.js
@@ -9,7 +9,7 @@ app.on('ready', function () {
       type: 'info',
       message: 'Success!',
       detail: 'You pressed the registered global shortcut keybinding.',
-      buttons: ['Yay']
+      buttons: ['OK']
     })
   })
 })

--- a/sections/menus/shortcuts.html
+++ b/sections/menus/shortcuts.html
@@ -35,7 +35,7 @@
         </button>
         <div class="demo-box">
           <p>
-            To try this demo, press <kbd class="normalize-to-platform">CommandOrControl+Alt+D</kbd> on your keyboard.
+            To try this demo, press <kbd class="normalize-to-platform">CommandOrControl+Alt+K</kbd> on your keyboard.
           </p>
 
           <p>


### PR DESCRIPTION
`Cmd-Alt-D` already does something on Mac so use `Cmd-Alt-K` instead (K for keyboard shortcut).

/cc @jlord 

Closes #179 