### PR TITLE
Remove tray icon when all windows are closed

### DIFF
--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -20,10 +20,10 @@ ipc.on('put-in-tray', function (event) {
   appIcon.setContextMenu(contextMenu)
 })
 
-ipc.on('remove-tray', function (event) {
+ipc.on('remove-tray', function () {
   appIcon.destroy()
 })
 
-app.on('window-all-closed', function (event) {
+app.on('window-all-closed', function () {
   appIcon.destroy()
 })

--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const electron = require('electron')
 const ipc = electron.ipcMain
+const app = electron.app
 
 let appIcon = null
 
@@ -20,5 +21,9 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function (event) {
+  appIcon.destroy()
+})
+
+app.on('window-all-closed', function (event) {
   appIcon.destroy()
 })


### PR DESCRIPTION
If a user hits the red traffic light on OS X to close the app window we keep the app running (this is default behavior) so it can be re-activated by clicking the dock icon. But! Should the user have the tray icon on at the time they close this leaves the tray icon there with no renderer process (and causes an error if you then try and remove the icon, see #189).

In the other OSes we quit the app and the tray icon is removed at that time. 

This PR adds a listener to the `all-windows-closed` event and removes the tray icon. Technically we only need to do this on OS X but I kept it simple and didn't check the platform (and packaged and tried it on Linux, I don't think it interferes with it's default behavior). 

cc @kevinsawicki 

Closes #189 
