### PR TITLE
Mac App Store build

### DIFF
--- a/assets/mac/child.plist
+++ b/assets/mac/child.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/assets/mac/info.plist
+++ b/assets/mac/info.plist
@@ -13,5 +13,7 @@
       <string>Electron API Demos Protocol</string>
     </dict>
   </array>
+  <key>ElectronTeamID</key>
+  <string>VEKTX9H2N7</string>
 </dict>
 </plist>

--- a/assets/mac/parent.plist
+++ b/assets/mac/parent.plist
@@ -5,6 +5,6 @@
     <key>com.apple.security.app-sandbox</key>
     <true/>
     <key>com.apple.security.application-groups</key>
-    <string>VEKTX9H2N7.com.electron.electron-api-demos</string>
+    <string>VEKTX9H2N7.com.github.electron-api-demos</string>
   </dict>
 </plist>

--- a/assets/mac/parent.plist
+++ b/assets/mac/parent.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <string>VEKTX9H2N7.com.electron.electron-api-demos</string>
+  </dict>
+</plist>

--- a/auto-updater.js
+++ b/auto-updater.js
@@ -7,6 +7,8 @@ const path = require('path')
 var state = 'checking'
 
 exports.initialize = function () {
+  if (process.mas) return
+
   autoUpdater.on('checking-for-update', function () {
     state = 'checking'
     exports.updateMenu()
@@ -37,6 +39,8 @@ exports.initialize = function () {
 }
 
 exports.updateMenu = function () {
+  if (process.mas) return
+
   var menu = Menu.getApplicationMenu()
   if (!menu) return
 

--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ function initialize () {
 
   app.on('ready', function () {
     createWindow()
-    autoUpdater.initialize()
+    // autoUpdater.initialize()
   })
 
   app.on('window-all-closed', function () {
@@ -67,6 +67,7 @@ function initialize () {
 // Returns true if the current version of the app should quit instead of
 // launching.
 function makeSingleInstance () {
+  if (process.mas) return false
   return app.makeSingleInstance(function () {
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore()

--- a/main.js
+++ b/main.js
@@ -68,6 +68,7 @@ function initialize () {
 // launching.
 function makeSingleInstance () {
   if (process.mas) return false
+
   return app.makeSingleInstance(function () {
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore()

--- a/main.js
+++ b/main.js
@@ -43,7 +43,7 @@ function initialize () {
 
   app.on('ready', function () {
     createWindow()
-    // autoUpdater.initialize()
+    autoUpdater.initialize()
   })
 
   app.on('window-all-closed', function () {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai-as-promised": "^5.1.0",
     "devtron": "^1.0.0",
     "electron-packager": "^7.0.1",
-    "electron-prebuilt": "~1.0.2",
+    "electron-prebuilt": "~1.1.3",
     "electron-windows-store": "^0.3.0",
     "electron-winstaller": "^2.2.0",
     "mocha": "^2.3.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "package": "npm run pack-mac && npm run pack-win && npm run pack-linux",
     "installer": "node ./script/installer.js",
     "windows-store": "node ./script/windows-store.js",
-    "mas": "electron-packager . --asar --overwrite --platform=mas --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out=out --osx-sign.identity='Developer ID Application: GitHub' --extend-info=assets/mac/info.plist",
+    "mas": "./script/mas.sh",
     "prepare-release": "npm run package && npm run sign-exe && npm run installer && npm run sign-installer",
     "release": "node ./script/release.js"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "package": "npm run pack-mac && npm run pack-win && npm run pack-linux",
     "installer": "node ./script/installer.js",
     "windows-store": "node ./script/windows-store.js",
+    "mas": "electron-packager . --asar --overwrite --platform=mas --arch=x64 --icon=assets/app-icon/mac/app.icns --prune=true --out=out --osx-sign.identity='Developer ID Application: GitHub' --extend-info=assets/mac/info.plist",
     "prepare-release": "npm run package && npm run sign-exe && npm run installer && npm run sign-installer",
     "release": "node ./script/release.js"
   },

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Name of your app.
+APP="Electron API Demos"
+
+# The path of your app to sign.
+APP_PATH="./out/Electron API Demos-mas-x64/Electron API Demos.app"
+
+# The path to the location you want to put the signed package.
+RESULT_PATH="./out/Electron API Demos.pkg"
+
+# The name of certificates you requested.
+APP_KEY="3rd Party Mac Developer Application: GitHub (VEKTX9H2N7)"
+INSTALLER_KEY="3rd Party Mac Developer Installer: GitHub (VEKTX9H2N7)"
+
+FRAMEWORKS_PATH="$APP_PATH/Contents/Frameworks"
+
+CHILD_PLIST="./assets/mac/child.plist"
+PARENT_PLIST="./assets/mac/parent.plist"
+
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/Electron Framework.framework/Versions/A/Electron Framework"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/Electron Framework.framework/Versions/A/Libraries/libnode.dylib"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/Electron Framework.framework"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper.app/Contents/MacOS/$APP Helper"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper.app/"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper EH.app/Contents/MacOS/$APP Helper EH"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper EH.app/"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper NP.app/Contents/MacOS/$APP Helper NP"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$FRAMEWORKS_PATH/$APP Helper NP.app/"
+codesign -s "$APP_KEY" -f --entitlements "$CHILD_PLIST" "$APP_PATH/Contents/MacOS/$APP"
+
+codesign -s "$APP_KEY" -f --entitlements "$PARENT_PLIST" "$APP_PATH"
+
+productbuild --component "$APP_PATH" /Applications --sign "$INSTALLER_KEY" "$RESULT_PATH"

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -2,33 +2,27 @@
 
 set -ex
 
+# TODO read these from package.json
+VERSION="1.0.2"
+APP="Electron API Demos"
+
 electron-packager . \
   --asar \
   --overwrite \
   --platform=mas \
   --app-bundle-id=com.github.electron-api-demos \
-  --app-version=1.0.2 \ # TODO read from package.json
+  --app-version=$VERSION \
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \
   --out=out \
   --extend-info=assets/mac/info.plist
 
-# Name of your app.
-APP="Electron API Demos"
-
-# The path of your app to sign.
-APP_PATH="./out/Electron API Demos-mas-x64/Electron API Demos.app"
-
-# The path to the location you want to put the signed package.
-RESULT_PATH="./out/Electron API Demos.pkg"
-
-# The name of certificates you requested.
+APP_PATH="./out/$APP-mas-x64/$APP.app"
+RESULT_PATH="./out/$APP.pkg"
 APP_KEY="3rd Party Mac Developer Application: GitHub (VEKTX9H2N7)"
 INSTALLER_KEY="3rd Party Mac Developer Installer: GitHub (VEKTX9H2N7)"
-
 FRAMEWORKS_PATH="$APP_PATH/Contents/Frameworks"
-
 CHILD_PLIST="./assets/mac/child.plist"
 PARENT_PLIST="./assets/mac/parent.plist"
 

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -6,6 +6,7 @@ electron-packager . \
   --asar \
   --overwrite \
   --platform=mas \
+  --app-bundle-id=com.github.electron-api-demos \
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -7,6 +7,7 @@ electron-packager . \
   --overwrite \
   --platform=mas \
   --app-bundle-id=com.github.electron-api-demos \
+  --app-version=1.0.2 \ # TODO read from package.json
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+set -ex
+
+electron-packager . \
+  --asar \
+  --overwrite \
+  --platform=mas \
+  --arch=x64 \
+  --icon=assets/app-icon/mac/app.icns \
+  --prune=true \
+  --out=out \
+  --extend-info=assets/mac/info.plist
+
 # Name of your app.
 APP="Electron API Demos"
 

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -2,22 +2,19 @@
 
 set -ex
 
-# TODO read these from package.json
-VERSION="1.0.2"
-APP="Electron API Demos"
-
 electron-packager . \
   --asar \
   --overwrite \
   --platform=mas \
   --app-bundle-id=com.github.electron-api-demos \
-  --app-version=$VERSION \
+  --app-version="$npm_package_version" \
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \
   --out=out \
   --extend-info=assets/mac/info.plist
 
+APP="$npm_package_productName"
 APP_PATH="./out/$APP-mas-x64/$APP.app"
 RESULT_PATH="./out/$APP.pkg"
 APP_KEY="3rd Party Mac Developer Application: GitHub (VEKTX9H2N7)"


### PR DESCRIPTION
Adds `npm run mas` to generate a build for the Mac App Store.

/cc @jlord 🍐 