### PR TITLE
Guard against no app icon

### DIFF
--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -15,7 +15,7 @@ ipc.on('put-in-tray', function (event) {
     label: 'Remove',
     click: function () {
       event.sender.send('tray-removed')
-      appIcon.destroy()
+      if (appIcon) appIcon.destroy()
     }
   }])
   appIcon.setToolTip('Electron Demo in the tray.')
@@ -23,9 +23,9 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function () {
-  appIcon.destroy()
+  if (appIcon) appIcon.destroy()
 })
 
 app.on('window-all-closed', function () {
-  appIcon.destroy()
+  if (appIcon) appIcon.destroy()
 })

--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -15,7 +15,7 @@ ipc.on('put-in-tray', function (event) {
     label: 'Remove',
     click: function () {
       event.sender.send('tray-removed')
-      if (appIcon) appIcon.destroy()
+      appIcon.destroy()
     }
   }])
   appIcon.setToolTip('Electron Demo in the tray.')
@@ -23,7 +23,7 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function () {
-  if (appIcon) appIcon.destroy()
+  appIcon.destroy()
 })
 
 app.on('window-all-closed', function () {


### PR DESCRIPTION
`window-all-closed` could emit on the app before the `appIcon` was created which would give you a `cannot call method destroy on undefined` error dialog.

/cc @jlord 

Refs https://github.com/electron/electron-api-demos/pull/210