### PR TITLE
Rename app to get approved in Mac App Store

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Electron API Demos</title>
 
   <link rel="stylesheet" href="assets/css/variables.css">
   <link rel="stylesheet" href="assets/css/nativize.css">

--- a/main-process/menus/application-menu.js
+++ b/main-process/menus/application-menu.js
@@ -119,6 +119,8 @@ let template = [{
 }]
 
 function addUpdateMenuItems (items, position) {
+  if (process.mas) return
+
   const version = electron.app.getVersion()
   let updateItems = [{
     label: `Version ${version}`,

--- a/main-process/menus/application-menu.js
+++ b/main-process/menus/application-menu.js
@@ -106,6 +106,16 @@ let template = [{
     label: 'Close',
     accelerator: 'CmdOrCtrl+W',
     role: 'close'
+  }, {
+    type: 'separator'
+  }, {
+    label: 'Reopen Window',
+    accelerator: 'CmdOrCtrl+Shift+T',
+    enabled: false,
+    key: 'reopenMenuItem',
+    click: function () {
+      app.emit('activate')
+    }
   }]
 }, {
   label: 'Help',
@@ -149,6 +159,23 @@ function addUpdateMenuItems (items, position) {
   items.splice.apply(items, [position, 0].concat(updateItems))
 }
 
+function findReopenMenuItem () {
+  const menu = Menu.getApplicationMenu()
+  if (!menu) return
+
+  let reopenMenuItem
+  menu.items.forEach(function (item) {
+    if (item.submenu) {
+      item.submenu.items.forEach(function (item) {
+        if (item.key === 'reopenMenuItem') {
+          reopenMenuItem = item
+        }
+      })
+    }
+  })
+  return reopenMenuItem
+}
+
 if (process.platform === 'darwin') {
   const name = electron.app.getName()
   template.unshift({
@@ -185,6 +212,7 @@ if (process.platform === 'darwin') {
       }
     }]
   })
+
   // Window menu.
   template[3].submenu.push({
     type: 'separator'
@@ -204,4 +232,14 @@ if (process.platform === 'win32') {
 app.on('ready', function () {
   const menu = Menu.buildFromTemplate(template)
   Menu.setApplicationMenu(menu)
+})
+
+app.on('browser-window-created', function () {
+  let reopenMenuItem = findReopenMenuItem()
+  if (reopenMenuItem) reopenMenuItem.enabled = false
+})
+
+app.on('window-all-closed', function () {
+  let reopenMenuItem = findReopenMenuItem()
+  if (reopenMenuItem) reopenMenuItem.enabled = true
 })

--- a/main.js
+++ b/main.js
@@ -20,7 +20,8 @@ function initialize () {
     var windowOptions = {
       width: 1080,
       minWidth: 680,
-      height: 840
+      height: 840,
+      title: process.mas ? 'Electron APIs' : app.getName()
     }
 
     if (process.platform === 'linux') {

--- a/main.js
+++ b/main.js
@@ -8,6 +8,8 @@ const app = electron.app
 
 const debug = /--debug/.test(process.argv[2])
 
+if (process.mas) app.setName('Electron APIs')
+
 var mainWindow = null
 
 function initialize () {
@@ -21,7 +23,7 @@ function initialize () {
       width: 1080,
       minWidth: 680,
       height: 840,
-      title: process.mas ? 'Electron APIs' : app.getName()
+      title: app.getName()
     }
 
     if (process.platform === 'linux') {

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -2,7 +2,11 @@
 
 set -ex
 
+# App Store does not allow the work "demos" in the name
+APP="Electron APIs"
+
 electron-packager . \
+  "$APP" \
   --asar \
   --overwrite \
   --platform=mas \
@@ -14,7 +18,6 @@ electron-packager . \
   --out=out \
   --extend-info=assets/mac/info.plist
 
-APP="$npm_package_productName"
 APP_PATH="./out/$APP-mas-x64/$APP.app"
 RESULT_PATH="./out/$APP.pkg"
 APP_KEY="3rd Party Mac Developer Application: GitHub (VEKTX9H2N7)"

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -12,6 +12,7 @@ electron-packager . \
   --platform=mas \
   --app-bundle-id=com.github.electron-api-demos \
   --app-version="$npm_package_version" \
+  --build-version="1.0.3" \
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \

--- a/script/mas.sh
+++ b/script/mas.sh
@@ -12,7 +12,7 @@ electron-packager . \
   --platform=mas \
   --app-bundle-id=com.github.electron-api-demos \
   --app-version="$npm_package_version" \
-  --build-version="1.0.3" \
+  --build-version="1.0.4" \
   --arch=x64 \
   --icon=assets/app-icon/mac/app.icns \
   --prune=true \

--- a/tests/index.js
+++ b/tests/index.js
@@ -69,7 +69,7 @@ describe('demo app', function () {
       .browserWindow.isFocused().should.eventually.be.true
       .browserWindow.getBounds().should.eventually.have.property('width').and.be.above(0)
       .browserWindow.getBounds().should.eventually.have.property('height').and.be.above(0)
-      .getTitle().should.eventually.equal('Electron API Demos')
+      .browserWindow.getTitle().should.eventually.equal('Electron API Demos')
       .waitForVisible('#about-modal').should.eventually.be.true
       .isVisible('.js-nav').should.eventually.be.false
       .click('button[id="get-started"]').pause(500)


### PR DESCRIPTION
The name `Electron API Demos` was rejected since you can't have `demo`/`demos`/`demonstration` in the name.

This renames it for only the app store build to `Electron APIs`.

Will merge if/when it gets approved.