### PR TITLE
Update screen information demo

### DIFF
--- a/renderer-process/system/screen-information.js
+++ b/renderer-process/system/screen-information.js
@@ -1,7 +1,7 @@
 const electronScreen = require('electron').screen
 
 const screenInfoBtn = document.getElementById('screen-info')
-const size = electronScreen.getPrimaryDisplay().workAreaSize
+const size = electronScreen.getPrimaryDisplay().size
 
 screenInfoBtn.addEventListener('click', function () {
   const message = `Your screen is: ${size.width} px x ${size.height} px`

--- a/renderer-process/system/screen-information.js
+++ b/renderer-process/system/screen-information.js
@@ -4,6 +4,6 @@ const screenInfoBtn = document.getElementById('screen-info')
 const size = electronScreen.getPrimaryDisplay().size
 
 screenInfoBtn.addEventListener('click', function () {
-  const message = `Your screen is: ${size.width} px x ${size.height} px`
+  const message = `Your screen is: ${size.width}px x ${size.height}px`
   document.getElementById('got-screen-info').innerHTML = message
 })

--- a/sections/system/app-sys-information.html
+++ b/sections/system/app-sys-information.html
@@ -98,6 +98,14 @@ process.versions.node</code></pre>
           <p>See the full <a href="http://electron.atom.io/docs/api/screen">screen documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> for more.</p>
           <h5>Renderer Process</h5>
           <pre><code data-path="renderer-process/system/screen-information.js"></pre></code>
+
+          <div class="demo-protip">
+            <h2>ProTip</h2>
+            <strong>Differences in dimensions.</strong>
+            <p>The <code>.size</code> method in the example returns the raw dimensions of the screen but because of system menu bars this may not be the actual space available for your app.</p>
+
+            <p>To get the dimensions of the available screen space use the <code>.workAreaSize</code> method. Using <code>.workArea</code> will return the coordinates as well as the dimensions of the available screen space.</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request changes the demo to use the `.size` method which provides the raw dimensions of the primary display. 

It then adds a ProTip section to let users know that they can use `.workArea` and `.workAreaSize` to get the dimensions of the space actually available to their app.

<img width="723" alt="screen shot 2016-06-08 at 1 27 12 pm" src="https://cloud.githubusercontent.com/assets/1305617/15909766/b60d346c-2d7c-11e6-8e45-4a3db138b209.png">

Closes #221 