### PR TITLE
Use close event instead of closed

### DIFF
--- a/renderer-process/windows/create-window.js
+++ b/renderer-process/windows/create-window.js
@@ -6,7 +6,7 @@ const newWindowBtn = document.getElementById('new-window')
 newWindowBtn.addEventListener('click', function (event) {
   const modalPath = path.join('file://', __dirname, '../../sections/windows/modal.html')
   let win = new BrowserWindow({ width: 400, height: 320 })
-  win.on('closed', function () { win = null })
+  win.on('close', function () { win = null })
   win.loadURL(modalPath)
   win.show()
 })

--- a/renderer-process/windows/frameless-window.js
+++ b/renderer-process/windows/frameless-window.js
@@ -6,7 +6,7 @@ const path = require('path')
 newWindowBtn.addEventListener('click', function (event) {
   const modalPath = path.join('file://', __dirname, '../../sections/windows/modal.html')
   let win = new BrowserWindow({ frame: false })
-  win.on('closed', function () { win = null })
+  win.on('close', function () { win = null })
   win.loadURL(modalPath)
   win.show()
 })

--- a/renderer-process/windows/manage-window.js
+++ b/renderer-process/windows/manage-window.js
@@ -9,7 +9,7 @@ manageWindowBtn.addEventListener('click', function (event) {
 
   win.on('resize', updateReply)
   win.on('move', updateReply)
-  win.on('closed', function () { win = null })
+  win.on('close', function () { win = null })
   win.loadURL(modalPath)
   win.show()
 

--- a/renderer-process/windows/process-crash.js
+++ b/renderer-process/windows/process-crash.js
@@ -22,7 +22,7 @@ processCrashBtn.addEventListener('click', function (event) {
     })
   })
 
-  win.on('closed', function () { win = null })
+  win.on('close', function () { win = null })
   win.loadURL(crashWinPath)
   win.show()
 })

--- a/renderer-process/windows/process-hang.js
+++ b/renderer-process/windows/process-hang.js
@@ -22,7 +22,7 @@ processHangBtn.addEventListener('click', function (event) {
     })
   })
 
-  win.on('closed', function () { win = null })
+  win.on('close', function () { win = null })
   win.loadURL(hangWinPath)
   win.show()
 })


### PR DESCRIPTION
Currently the app shows an exception dialog in the following scenario:

- Start the app
- Click Create and manage windows from the left nav
- Expand Create a new window
- Click View Demo
- Quit the app

<img width="532" alt="screen shot 2016-06-10 at 11 05 55 am" src="https://cloud.githubusercontent.com/assets/671378/15974040/52678676-2efb-11e6-82f3-b982ec710779.png">

I think this is happening because the `closed` event is being listened for over RPC and so the window is already released by the time the event fires.

This pull request switches to using the `close` event which fires before `closed` and seems to prevent this error while still `null`-ing out the `win` variable.

http://electron.atom.io/docs/api/browser-window/#event-close

/cc @jlord 