### PR TITLE
Enable user-selected entitlement for open/save demo

### DIFF
--- a/assets/mac/parent.plist
+++ b/assets/mac/parent.plist
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.application-groups</key>
     <string>VEKTX9H2N7.com.github.electron-api-demos</string>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Adding this [entitlement](https://developer.apple.com/library/mac/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/EnablingAppSandbox.html#//apple_ref/doc/uid/TP40011195-CH4-SW1) gets the open and save dialog demos working in the mac app store build.

/cc @jlord 👀 

Refs #227 