### PR TITLE
Enable sending events to finder for pdf demo

### DIFF
--- a/assets/mac/parent.plist
+++ b/assets/mac/parent.plist
@@ -6,5 +6,9 @@
     <true/>
     <key>com.apple.security.application-groups</key>
     <string>VEKTX9H2N7.com.github.electron-api-demos</string>
+    <key>com.apple.security.temporary-exception.apple-events</key>
+    <array>
+      <string>com.apple.finder</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
Adding this entitlement gets the open pdf demo working in the mac app store build.

The screenshot demo still fails for some reason with the following though:

```
6/13/16 11:04:19.434 AM Finder[501]: AppleEvents/sandbox: Returning errAEPrivilegeError/-10004 and denying dispatch of event aevt/odoc from process 'Electron APIs Helper'/0x0-0x1994993, pid=63882, because it is not entitled to send an AppleEvent to this process.
```

Refs #227 