### PR TITLE
Use shell.openExternal instead of shell.openItem

### DIFF
--- a/main-process/media/pdf.js
+++ b/main-process/media/pdf.js
@@ -16,7 +16,7 @@ ipc.on('print-to-pdf', function (event) {
       if (error) {
         throw error
       }
-      shell.openItem(pdfPath)
+      shell.openExternal('file://' + pdfPath)
       event.sender.send('wrote-pdf', pdfPath)
     })
   })

--- a/renderer-process/media/desktop-capturer.js
+++ b/renderer-process/media/desktop-capturer.js
@@ -24,7 +24,7 @@ screenshot.addEventListener('click', function (event) {
 
         fs.writeFile(screenshotPath, source.thumbnail.toPng(), function (error) {
           if (error) return console.log(error)
-          shell.openItem(screenshotPath)
+          shell.openExternal('file://' + screenshotPath)
           const message = `Saved screenshot to: ${screenshotPath}`
           screenshotMsg.textContent = message
         })


### PR DESCRIPTION
This appears to fix the pdf and screenshot demos in the mac app store build and still opens the Preview app on Mac and photos/IE on Windows so it seems to behave the same.

This is an alternative to #230 

Refs #227 