### PR TITLE
Don't appIcon.destroy() in click event

### DIFF
--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -15,9 +15,6 @@ ipc.on('put-in-tray', function (event) {
     label: 'Remove',
     click: function () {
       event.sender.send('tray-removed')
-      setImmediate(function () {
-        appIcon.destroy()
-      })
     }
   }])
   appIcon.setToolTip('Electron Demo in the tray.')
@@ -25,15 +22,11 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function () {
-  setImmediate(function () {
     appIcon.destroy()
-  })
 })
 
 app.on('window-all-closed', function () {
   if (appIcon) {
-    setImmediate(function () {
       appIcon.destroy()
-    })
   }
 })

--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -15,7 +15,9 @@ ipc.on('put-in-tray', function (event) {
     label: 'Remove',
     click: function () {
       event.sender.send('tray-removed')
-      appIcon.destroy()
+      setImmediate(function () {
+        appIcon.destroy()
+      })
     }
   }])
   appIcon.setToolTip('Electron Demo in the tray.')
@@ -23,9 +25,15 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function () {
-  appIcon.destroy()
+  setImmediate(function () {
+    appIcon.destroy()
+  })
 })
 
 app.on('window-all-closed', function () {
-  if (appIcon) appIcon.destroy()
+  if (appIcon) {
+    setImmediate(function () {
+      appIcon.destroy()
+    })
+  }
 })

--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -26,5 +26,5 @@ ipc.on('remove-tray', function () {
 })
 
 app.on('window-all-closed', function () {
-  if (appIcon) { appIcon.destroy() }
+  if (appIcon) appIcon.destroy()
 })

--- a/main-process/native-ui/tray/tray.js
+++ b/main-process/native-ui/tray/tray.js
@@ -22,11 +22,9 @@ ipc.on('put-in-tray', function (event) {
 })
 
 ipc.on('remove-tray', function () {
-    appIcon.destroy()
+  appIcon.destroy()
 })
 
 app.on('window-all-closed', function () {
-  if (appIcon) {
-      appIcon.destroy()
-  }
+  if (appIcon) { appIcon.destroy() }
 })

--- a/renderer-process/native-ui/tray/tray.js
+++ b/renderer-process/native-ui/tray/tray.js
@@ -17,6 +17,7 @@ trayBtn.addEventListener('click', function (event) {
 })
 // Tray removed from context menu on icon
 ipc.on('tray-removed', function () {
+  ipc.send('remove-tray')
   trayOn = false
   document.getElementById('tray-countdown').innerHTML = ''
 })


### PR DESCRIPTION
Don't call `appIcon.destroy()` in the click event, because it causes a crash in OS X 10.10.x. Instead, use `ipc` and the `remove-tray` channel. 

Closes #220 