### PR TITLE
Update font stack

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -16,7 +16,7 @@
 
 html {
   height: 100%;
-  font-family: system, -apple-system, '.SFNSText-Regular', 'SF UI Text', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
+  font-family: 'BlinkMacSystemFont', 'Lucida Grande', 'Segoe UI', Ubuntu, Cantarell, sans-serif;
   font-size: 14px;
   line-height: 1.5;
   overflow: hidden; /* Prevents rubber-band scrolling of the whole "page" */


### PR DESCRIPTION
This updates the font stack.

`'.SFNSText-Regular'` is a private font name and looks like it [will be removed/changed](https://github.com/atom/atom/pull/12002#issue-161019262) in macOS Sierra. `'BlinkMacSystemFont'` should be more future proof.
