### PR TITLE
Add spec that audits accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
 
     <footer class="nav-footer">
       <button type="button" id="button-about" data-modal="about" class="nav-footer-button">About</button>
-      <a class="nav-footer-logo" href="https://github.com">
+      <a class="nav-footer-logo" href="https://github.com" aria-label="Homepage">
         <svg class="nav-footer-icon"><use xlink:href="assets/img/icons.svg#icon-love"></use></svg>
       </a>
     </footer>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "request": "^2.70.0",
     "rimraf": "^2.5.2",
     "signcode": "^0.4.0",
-    "spectron": "~3.2.5",
+    "spectron": "~3.2.6",
     "standard": "^6.0.8"
   },
   "dependencies": {

--- a/sections/about.html
+++ b/sections/about.html
@@ -2,7 +2,7 @@
   <div id="about-modal" class="about modal">
     <div class="about-wrapper">
       <header class="about-header">
-        <img class="about-logo" src="assets/img/about.png" srcset="assets/img/about.png 1x, assets/img/about@2x.png 2x">
+        <img class="about-logo" src="assets/img/about.png" srcset="assets/img/about.png 1x, assets/img/about@2x.png 2x" alt="Electron API Demos">
       </header>
       <main class="about-sections">
         <section class="about-section play-along">

--- a/sections/system/clipboard.html
+++ b/sections/system/clipboard.html
@@ -21,7 +21,7 @@
         <div class="demo-box">
           <div class="demo-controls">
             <button class="demo-button" id="copy-to">Copy</button>
-            <input class="demo-input" id="copy-to-input" placeholder="Click copy."></input>
+            <input class="demo-input" id="copy-to-input" aria-label="Click copy" placeholder="Click copy."></input>
           </div>
           <p>In this example we copy a phrase to the clipboard. After clicking 'Copy' use the text area to paste (CMD + V or CTRL + V) the phrase from the clipboard.</p>
           <h5>Renderer Process</h5>

--- a/tests/index.js
+++ b/tests/index.js
@@ -47,18 +47,16 @@ describe('demo app', function () {
 
     app.client.addCommand('expandDemos', function () {
       return this.execute(function () {
-        let demos = document.querySelectorAll('.demo-wrapper')
-        for (let i = 0; i < demos.length; i++) {
-          demos[i].classList.add('is-open')
+        for (let demo of document.querySelectorAll('.demo-wrapper')) {
+          demo.classList.add('is-open')
         }
       })
     })
 
     app.client.addCommand('collapseDemos', function () {
       return this.execute(function () {
-        let demos = document.querySelectorAll('.demo-wrapper')
-        for (let i = 0; i < demos.length; i++) {
-          demos[i].classList.remove('is-open')
+        for (let demo of document.querySelectorAll('.demo-wrapper')) {
+          demo.classList.remove('is-open')
         }
       })
     })

--- a/tests/index.js
+++ b/tests/index.js
@@ -121,4 +121,9 @@ describe('demo app', function () {
         })
     })
   })
+
+  it('does not contain any accessibility warnings or errors', function () {
+    return app.client.waitUntilWindowLoaded()
+      .auditAccessibility().should.eventually.have.property('failed').and.be.false
+  })
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -32,6 +32,50 @@ describe('demo app', function () {
   }
 
   const setupApp = function (app) {
+    app.client.addCommand('dismissAboutPage', function () {
+      return this.isVisible('.js-nav').then(function (navVisible) {
+        if (!navVisible) {
+          return this.click('button[id="get-started"]').pause(500)
+        }
+      })
+    })
+
+    app.client.addCommand('selectSection', function (section) {
+      return this.click('button[data-section="' + section + '"]').pause(100)
+        .waitForVisible('#' + section + '-section')
+    })
+
+    app.client.addCommand('expandDemos', function () {
+      return this.execute(function () {
+        let demos = document.querySelectorAll('.demo-wrapper')
+        for (let i = 0; i < demos.length; i++) {
+          demos[i].classList.add('is-open')
+        }
+      })
+    })
+
+    app.client.addCommand('collapseDemos', function () {
+      return this.execute(function () {
+        let demos = document.querySelectorAll('.demo-wrapper')
+        for (let i = 0; i < demos.length; i++) {
+          demos[i].classList.remove('is-open')
+        }
+      })
+    })
+
+    app.client.addCommand('auditSectionAccessibility', function (section) {
+      const options = {
+        ignoreRules: ['AX_COLOR_01', 'AX_TITLE_01']
+      }
+      return this.selectSection(section)
+        .expandDemos()
+        .auditAccessibility(options).then(function (audit) {
+          if (audit.failed) {
+            throw Error(section + ' section failed accessibility audit\n' + audit.message)
+          }
+        })
+    })
+
     chaiAsPromised.transferPromiseness = app.transferPromiseness
     return app.client.waitUntilWindowLoaded()
   }
@@ -81,13 +125,11 @@ describe('demo app', function () {
 
   describe('when clicking on a section from the nav bar', function () {
     it('it shows the selected section in the main area', function () {
-      return app.client.isVisible('#windows-section').should.eventually.be.true
-        .click('button[data-section="windows"]').pause(100)
-        .waitForVisible('#windows-section')
+      return app.client.dismissAboutPage()
+        .selectSection('windows')
         .isExisting('button.is-selected[data-section="windows"]').should.eventually.be.true
         .isVisible('#pdf-section').should.eventually.be.false
-        .click('button[data-section="pdf"]').pause(100)
-        .waitForVisible('#pdf-section')
+        .selectSection('pdf')
         .isVisible('#windows-section').should.eventually.be.false
         .isExisting('button.is-selected[data-section="windows"]').should.eventually.be.false
         .isExisting('button.is-selected[data-section="pdf"]').should.eventually.be.true
@@ -99,8 +141,9 @@ describe('demo app', function () {
       let onlyFirstVisible = Array(27).fill(false)
       onlyFirstVisible[0] = true
 
-      return app.client.click('button[data-section="windows"]')
-        .waitForVisible('#windows-section')
+      return app.client.dismissAboutPage()
+        .collapseDemos()
+        .selectSection('windows')
         .click('.js-container-target')
         .waitForVisible('.demo-box')
         .isVisible('.demo-box').should.eventually.deep.equal(onlyFirstVisible)
@@ -123,7 +166,19 @@ describe('demo app', function () {
   })
 
   it('does not contain any accessibility warnings or errors', function () {
-    return app.client.waitUntilWindowLoaded()
-      .auditAccessibility().should.eventually.have.property('failed').and.be.false
+    return app.client.dismissAboutPage()
+      .auditSectionAccessibility('windows')
+      .auditSectionAccessibility('crash-hang')
+      .auditSectionAccessibility('menus')
+      .auditSectionAccessibility('shortcuts')
+      .auditSectionAccessibility('ex-links-file-manager')
+      .auditSectionAccessibility('dialogs')
+      .auditSectionAccessibility('tray')
+      .auditSectionAccessibility('ipc')
+      .auditSectionAccessibility('app-sys-information')
+      .auditSectionAccessibility('clipboard')
+      .auditSectionAccessibility('protocol')
+      .auditSectionAccessibility('pdf')
+      .auditSectionAccessibility('desktop-capturer')
   })
 })


### PR DESCRIPTION
This pull request adds a spec that audits each section for accessibility errors returned from Spectron's `auditAccessibility()` helper.

The contrast rule is disabled due to the app using background gradients which are not currently supported by the accessibility library, https://github.com/GoogleChrome/accessibility-developer-tools/issues/79

The changes to the `.html` files were to get the specs passing, there were a few current issues with missing labels and alt text.

/cc @jlord @zeke 