### PR TITLE
Add snazzy to linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "start": "electron .",
     "dev": "electron . --debug",
-    "lint": "standard",
+    "lint": "standard | snazzy",
     "test": "mocha tests && npm run lint",
     "sign-exe": "signcode ./out/ElectronAPIDemos-win32-ia32/ElectronAPIDemos.exe --cert ~/electron-api-demos.p12 --prompt --name 'Electron API Demos' --url 'http://electron.atom.io'",
     "sign-installer": "signcode ./out/windows-installer/ElectronAPIDemosSetup.exe --cert ~/electron-api-demos.p12 --prompt --name 'Electron API Demos' --url 'http://electron.atom.io'",
@@ -49,6 +49,7 @@
     "request": "^2.70.0",
     "rimraf": "^2.5.2",
     "signcode": "^0.4.0",
+    "snazzy": "^5.0.0",
     "spectron": "~3.2.6",
     "standard": "^6.0.8"
   },


### PR DESCRIPTION
Love the demo. Was playing around with it and it took me an extra minute or two to figure out what linting errors I was tripping after adjusting some files. Adding [`snazzy`](https://www.npmjs.com/package/snazzy) helped me see what the errors are:

<img width="665" alt="screen shot 2016-09-22 at 4 49 56 pm" src="https://cloud.githubusercontent.com/assets/2916945/18767474/f4a1a602-80e4-11e6-8a5e-4c02425074df.png">

Feel free to just close if adding `snazzy` is not desired.