### PR TITLE
Translations heading was not being rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ $ npm run dev
 
  [Read the docs](docs.md) to learn more about how this app is built or how to [add a new demo](docs.md#add-a-section-or-demo).
 
- ## Translations
+## Translations
 
 A Chinese translation of this app is available at [`fuchao2012/zh-cn-Electron-API-Demos`](https://github.com/fuchao2012/zh-cn-Electron-API-Demos). Note: this version is maintained by outside contributors and may not always be in sync with this version.


### PR DESCRIPTION
Thanks for the great examples!

While [Updating the Accessibility Tab in devtron](https://github.com/electron/devtron/pull/87) I noticed this small mistake.