### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,24 +39,24 @@
   "homepage": "https://github.com/electron/electron-api-demos#readme",
   "devDependencies": {
     "chai": "^3.4.1",
-    "chai-as-promised": "^5.1.0",
+    "chai-as-promised": "^6.0.0",
     "devtron": "^1.3.0",
     "electron": "^1.3.5",
-    "electron-packager": "^7.0.1",
-    "electron-windows-store": "^0.3.0",
+    "electron-packager": "^8.0.0",
+    "electron-windows-store": "^0.5.2",
     "electron-winstaller": "^2.2.0",
-    "mocha": "^2.3.4",
+    "mocha": "^3.1.0",
     "request": "^2.70.0",
     "rimraf": "^2.5.2",
-    "signcode": "^0.4.0",
+    "signcode": "^0.5.0",
     "snazzy": "^5.0.0",
-    "spectron": "~3.2.6",
-    "standard": "^6.0.8"
+    "spectron": "^3.4.0",
+    "standard": "^8.2.0"
   },
   "dependencies": {
     "electron-json-storage": "^2.0.0",
     "electron-shortcut-normalizer": "^1.0.0",
-    "glob": "^6.0.4",
+    "glob": "^7.1.0",
     "highlight.js": "^9.3.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -43,14 +43,13 @@
     "devtron": "^1.3.0",
     "electron": "^1.3.5",
     "electron-packager": "^8.0.0",
-    "electron-windows-store": "^0.5.2",
     "electron-winstaller": "^2.2.0",
     "mocha": "^3.1.0",
     "request": "^2.70.0",
     "rimraf": "^2.5.2",
     "signcode": "^0.5.0",
     "snazzy": "^5.0.0",
-    "spectron": "^3.4.0",
+    "spectron": "~3.4.0",
     "standard": "^8.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
When running `npm install` today, I see a lot of deprecation notices:

![screen shot 2016-09-28 at 11 46 47 am](https://cloud.githubusercontent.com/assets/2289/18927775/1ec3a3b8-8572-11e6-9af9-9a5a2239f8b4.png)

I used [npm-check](http://ghub.io/npm-check) to update outdated dependencies, and now most of those warnings are gone.
