### PR TITLE
Fixes for tests for Windows

### DIFF
--- a/tests/index.js
+++ b/tests/index.js
@@ -17,26 +17,24 @@ describe('demo app', function () {
 
   let app
 
-  const removeStoredPreferences = function () {
+  const getUserDataPath = function () {
     const productName = require('../package').productName
-
-    let userDataPath = ''
     switch (process.platform) {
       case 'darwin':
-        userDataPath = path.join(process.env.HOME, 'Library', 'Application Support', productName)
-        break
+        return path.join(process.env.HOME, 'Library', 'Application Support', productName)
       case 'win32':
-        userDataPath = path.join(process.env.APPDATA, productName)
-        break
+        return path.join(process.env.APPDATA, productName)
       case 'freebsd':
       case 'linux':
       case 'sunos':
-        userDataPath = path.join(process.env.HOME, '.config', productName)
-        break
+        return path.join(process.env.HOME, '.config', productName)
       default:
         throw new Error(`Unknown userDataPath path for platform ${process.platform}`)
     }
+  }
 
+  const removeStoredPreferences = function () {
+    const userDataPath = getUserDataPath()
     try {
       fs.unlinkSync(path.join(userDataPath, 'activeDemoButtonId.json'))
     } catch (error) {
@@ -121,6 +119,14 @@ describe('demo app', function () {
     if (app && app.isRunning()) {
       return app.stop()
     }
+  })
+
+  it('checks hardcoded path for userData is correct', function () {
+    return app.client.execute(function () {
+      return require('electron').remote.app.getPath('userData')
+    }).then(function (result) {
+      return result.value
+    }).should.eventually.equal(getUserDataPath())
   })
 
   it('opens a window displaying the about page', function () {

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Application = require('spectron').Application
+const electron = require('electron')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
@@ -80,7 +81,7 @@ describe('demo app', function () {
 
   const startApp = function () {
     app = new Application({
-      path: path.join(__dirname, '..', 'node_modules', '.bin', 'electron'),
+      path: electron,
       args: [
         path.join(__dirname, '..')
       ],

--- a/tests/index.js
+++ b/tests/index.js
@@ -19,7 +19,24 @@ describe('demo app', function () {
 
   const removeStoredPreferences = function () {
     const productName = require('../package').productName
-    const userDataPath = path.join(process.env.HOME, 'Library', 'Application Support', productName)
+
+    let userDataPath = ''
+    switch (process.platform) {
+      case 'darwin':
+        userDataPath = path.join(process.env.HOME, 'Library', 'Application Support', productName)
+        break
+      case 'win32':
+        userDataPath = path.join(process.env.APPDATA, productName)
+        break
+      case 'freebsd':
+      case 'linux':
+      case 'sunos':
+        userDataPath = path.join(process.env.HOME, '.config', productName)
+        break
+      default:
+        throw new Error(`Unknown userDataPath path for platform ${process.platform}`)
+    }
+
     try {
       fs.unlinkSync(path.join(userDataPath, 'activeDemoButtonId.json'))
     } catch (error) {


### PR DESCRIPTION
Tests were failing on windows. 

The app did not seem to start, looks like this issue: http://stackoverflow.com/questions/37343150/spectron-and-electron-without-exe-files

Eventually, the timeout will fire without even the `before` to be finished. 

This PR fixes that. 

I've also addressed the `userDataPath` since it was only configured for OSX. 

Tests are still failing on Windows btw, but that seems unrelated. This line evaluates to `false` when I run the tests.

      .browserWindow.isFocused().should.eventually.be.true

https://github.com/electron/electron-api-demos/blob/master/tests/index.js#L113
