### PR TITLE
Keep electron and spectron minor version numbers in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai": "^3.4.1",
     "chai-as-promised": "^6.0.0",
     "devtron": "^1.3.0",
-    "electron": "^1.3.5",
+    "electron": "~1.6.2",
     "electron-packager": "^8.0.0",
     "electron-winstaller": "^2.2.0",
     "mocha": "^3.1.0",
@@ -49,7 +49,7 @@
     "rimraf": "^2.5.2",
     "signcode": "^0.5.0",
     "snazzy": "^5.0.0",
-    "spectron": "~3.4.0",
+    "spectron": "~3.6.0",
     "standard": "^8.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
Working toward #294 

I just did a fresh `rm -rf node_modules && npm i && npm t`. The app window appears on screen, but the test suite is hanging on setup and it times out before any of the tests are run.

The [docs for `app.start()`](https://github.com/electron/spectron/#start) say that it returns a promise when the app is ready, but it seems the `setupApp` function is never reached.


Any ideas, @kevinsawicki?