### PR TITLE
Replace `electron-json-storage` with `electron-settings`

### DIFF
--- a/assets/demo-btns.js
+++ b/assets/demo-btns.js
@@ -1,20 +1,26 @@
-const storage = require('electron-json-storage')
+const settings = require('electron-settings')
 
 const demoBtns = document.querySelectorAll('.js-container-target')
 // Listen for demo button clicks
 Array.prototype.forEach.call(demoBtns, function (btn) {
   btn.addEventListener('click', function (event) {
-    event.target.parentElement.classList.toggle('is-open')
+    const parent = event.target.parentElement;
 
-    // Save currently active demo button in localStorage
-    storage.set('activeDemoButtonId', event.target.getAttribute('id'), function (err) {
-      if (err) return console.error(err)
-    })
+    // Toggles the "is-open" class on the demo's parent element.
+    parent.classList.toggle('is-open')
+
+    // Saves the active demo if it is open, or clears it if the demo was user
+    // collapsed by the user
+    if (parent.classList.contains('is-open')) {
+      settings.set('activeDemoButtonId', event.target.getAttribute('id'))
+    } else {
+      settings.delete('activeDemoButtonId')
+    }
   })
 })
 
 // Default to the demo that was active the last time the app was open
-storage.get('activeDemoButtonId', function (err, id) {
-  if (err) return console.error(err)
-  if (id && id.length) document.getElementById(id).click()
-})
+const buttonId = settings.get('activeDemoButtonId');
+if (buttonId) {
+  document.getElementById(buttonId).click()
+}

--- a/assets/demo-btns.js
+++ b/assets/demo-btns.js
@@ -4,7 +4,7 @@ const demoBtns = document.querySelectorAll('.js-container-target')
 // Listen for demo button clicks
 Array.prototype.forEach.call(demoBtns, function (btn) {
   btn.addEventListener('click', function (event) {
-    const parent = event.target.parentElement;
+    const parent = event.target.parentElement
 
     // Toggles the "is-open" class on the demo's parent element.
     parent.classList.toggle('is-open')
@@ -20,7 +20,7 @@ Array.prototype.forEach.call(demoBtns, function (btn) {
 })
 
 // Default to the demo that was active the last time the app was open
-const buttonId = settings.get('activeDemoButtonId');
+const buttonId = settings.get('activeDemoButtonId')
 if (buttonId) {
   document.getElementById(buttonId).click()
 }

--- a/assets/nav.js
+++ b/assets/nav.js
@@ -22,7 +22,7 @@ function handleSectionTrigger (event) {
 
   // Save currently active button in localStorage
   const buttonId = event.target.getAttribute('id')
-  settings.set('activeSectionButtonId', buttonId);
+  settings.set('activeSectionButtonId', buttonId)
 }
 
 function activateDefaultSection () {

--- a/assets/nav.js
+++ b/assets/nav.js
@@ -1,18 +1,4 @@
-const storage = require('electron-json-storage')
-
-// Default to the view that was active the last time the app was open
-storage.get('activeSectionButtonId', function (err, id) {
-  if (err) return console.error(err)
-
-  if (id && id.length) {
-    showMainContent()
-    const section = document.getElementById(id)
-    if (section) section.click()
-  } else {
-    activateDefaultSection()
-    displayAbout()
-  }
-})
+const settings = require('electron-settings')
 
 document.body.addEventListener('click', function (event) {
   if (event.target.dataset.section) {
@@ -36,9 +22,7 @@ function handleSectionTrigger (event) {
 
   // Save currently active button in localStorage
   const buttonId = event.target.getAttribute('id')
-  storage.set('activeSectionButtonId', buttonId, function (err) {
-    if (err) return console.error(err)
-  })
+  settings.set('activeSectionButtonId', buttonId);
 }
 
 function activateDefaultSection () {
@@ -78,4 +62,15 @@ function hideAllSectionsAndDeselectButtons () {
 
 function displayAbout () {
   document.querySelector('#about-modal').classList.add('is-shown')
+}
+
+// Default to the view that was active the last time the app was open
+const sectionId = settings.get('activeSectionButtonId')
+if (sectionId) {
+  showMainContent()
+  const section = document.getElementById(sectionId)
+  if (section) section.click()
+} else {
+  activateDefaultSection()
+  displayAbout()
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard": "^8.2.0"
   },
   "dependencies": {
-    "electron-json-storage": "^2.0.0",
+    "electron-settings": "^3.0.5",
     "electron-shortcut-normalizer": "^1.0.0",
     "glob": "^7.1.0",
     "highlight.js": "^9.3.0"

--- a/test/index.js
+++ b/test/index.js
@@ -36,12 +36,7 @@ describe('demo app', function () {
   const removeStoredPreferences = function () {
     const userDataPath = getUserDataPath()
     try {
-      fs.unlinkSync(path.join(userDataPath, 'activeDemoButtonId.json'))
-    } catch (error) {
-      if (error.code !== 'ENOENT') throw error
-    }
-    try {
-      fs.unlinkSync(path.join(userDataPath, 'activeSectionButtonId.json'))
+      fs.unlinkSync(path.join(userDataPath, 'Settings'))
     } catch (error) {
       if (error.code !== 'ENOENT') throw error
     }


### PR DESCRIPTION
Note: In **`nav.js`** I had to move the logic to set the saved section as the active section from the top of the file to the bottom, because the `click` handlers had to be bound first. Previously, electron-json-config returned a callback inside of which `click()` was called. It was a race condition and came to light when implementing electron-settings because the logic here is synchronous.

I also delete the active demo setting if the user collapses the demo, in **`demo-btns.js`**.

Fixes #251 