### PR TITLE
Update electron-settings to version 3.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "standard": "^8.2.0"
   },
   "dependencies": {
-    "electron-settings": "^3.0.5",
+    "electron-settings": "^3.0.7",
     "electron-shortcut-normalizer": "^1.0.0",
     "glob": "^7.1.0",
     "highlight.js": "^9.3.0"


### PR DESCRIPTION
Previous versions had `electron` as a dependency, whereas it should be a dev dependency. This was causing issues with code signing the application with an Apple Developer ID Application certificate.

See [electron-settings#68](https://github.com/nathanbuchar/electron-settings/issues/68).