### PR TITLE
Fix multiple handlers subscriptions

### DIFF
--- a/renderer-process/windows/using-window-events.js
+++ b/renderer-process/windows/using-window-events.js
@@ -25,10 +25,9 @@ manageWindowBtn.addEventListener('click', function () {
   function hideFocusBtn () {
     focusModalBtn.classList.add('disappear')
     focusModalBtn.classList.remove('smooth-appear')
-    focusModalBtn.removeEventListener('click', clickHandler);
+    focusModalBtn.removeEventListener('click', clickHandler)
   }
-
-  function clickHandler(){
+  function clickHandler () {
     win.focus()
   }
 })

--- a/renderer-process/windows/using-window-events.js
+++ b/renderer-process/windows/using-window-events.js
@@ -20,10 +20,15 @@ manageWindowBtn.addEventListener('click', function () {
     if (!win) return
     focusModalBtn.classList.add('smooth-appear')
     focusModalBtn.classList.remove('disappear')
-    focusModalBtn.addEventListener('click', function () { win.focus() })
+    focusModalBtn.addEventListener('click', clickHandler)
   }
   function hideFocusBtn () {
     focusModalBtn.classList.add('disappear')
     focusModalBtn.classList.remove('smooth-appear')
+    focusModalBtn.removeEventListener('click', clickHandler);
+  }
+
+  function clickHandler(){
+    win.focus()
   }
 })


### PR DESCRIPTION
This is just a minor fix to avoid multiple subscriptions to a click handler. In this particular case it is not essential as win.focus() would be idempotent, but considering click handler may be something more complex the pattern itself may be misleading.