### PR TITLE
Fix typo (from interupting to interrupting).

### DIFF
--- a/sections/native-ui/dialogs.html
+++ b/sections/native-ui/dialogs.html
@@ -8,7 +8,7 @@
         </h1>
         <h3>The <code>dialog</code> module in Electron allows you to use native system dialogs for opening files or directories, saving a file or displaying informational messages.</h3>
 
-        <p>This is a main process module because this process is more efficient with native utilities and it allows the call to happen without interupting the visible elements in your page's renderer process.</p>
+        <p>This is a main process module because this process is more efficient with native utilities and it allows the call to happen without interrupting the visible elements in your page's renderer process.</p>
 
         <p>Open the <a href="http://electron.atom.io/docs/api/dialog/">full API documentation<span class="u-visible-to-screen-reader">(opens in new window)</span></a> in your browser.</p>
       </div>


### PR DESCRIPTION
Fixed typo from "interupting" to "interrupting".