### PR TITLE
Split tests into setup.js and index.js

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ describe('demo app', function () {
   }
 
   const restartApp = () => {
-    app.restart().then((ret) => {
+    return app.restart().then((ret) => {
       setup.setupApp(ret)
     })
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const {Application} = require('spectron')
+const Application = require('spectron').Application
 const electron = require('electron')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/index.js
+++ b/test/index.js
@@ -17,53 +17,6 @@ describe('demo app', function () {
 
   let app
 
-  const setupApp = function (app) {
-    app.client.addCommand('dismissAboutPage', function () {
-      return this.isVisible('.js-nav').then(function (navVisible) {
-        if (!navVisible) {
-          return this.click('button[id="get-started"]').pause(500)
-        }
-      })
-    })
-
-    app.client.addCommand('selectSection', function (section) {
-      return this.click('button[data-section="' + section + '"]').pause(100)
-        .waitForVisible('#' + section + '-section')
-    })
-
-    app.client.addCommand('expandDemos', function () {
-      return this.execute(function () {
-        for (let demo of document.querySelectorAll('.demo-wrapper')) {
-          demo.classList.add('is-open')
-        }
-      })
-    })
-
-    app.client.addCommand('collapseDemos', function () {
-      return this.execute(function () {
-        for (let demo of document.querySelectorAll('.demo-wrapper')) {
-          demo.classList.remove('is-open')
-        }
-      })
-    })
-
-    app.client.addCommand('auditSectionAccessibility', function (section) {
-      const options = {
-        ignoreRules: ['AX_COLOR_01', 'AX_TITLE_01']
-      }
-      return this.selectSection(section)
-        .expandDemos()
-        .auditAccessibility(options).then(function (audit) {
-          if (audit.failed) {
-            throw Error(section + ' section failed accessibility audit\n' + audit.message)
-          }
-        })
-    })
-
-    chaiAsPromised.transferPromiseness = app.transferPromiseness
-    return app.client.waitUntilWindowLoaded()
-  }
-
   const startApp = () => {
     app = new Application({
       path: electron,
@@ -73,10 +26,16 @@ describe('demo app', function () {
       waitTimeout: timeout
     })
 
-    return app.start().then(setupApp)
+    return app.start().then((ret) => {
+      setup.setupApp(ret)
+    })
   }
 
-  const restartApp = () => app.restart().then(setupApp)
+  const restartApp = () => {
+    app.restart().then((ret) => {
+      setup.setupApp(ret)
+    })
+  }
 
   before(() => {
     setup.removeStoredPreferences()

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,7 @@ const electron = require('electron')
 const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 const path = require('path')
-const setup = require('./setup.js')
+const setup = require('./setup')
 
 chai.should()
 chai.use(chaiAsPromised)

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const path = require('path')
 const fs = require('fs')
 const chaiAsPromised = require('chai-as-promised')

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,32 @@
+const path = require('path')
+const fs = require('fs')
+
+const getUserDataPath = function () {
+  const productName = require('../package').productName
+  switch (process.platform) {
+    case 'darwin':
+      return path.join(process.env.HOME, 'Library', 'Application Support', productName)
+    case 'win32':
+      return path.join(process.env.APPDATA, productName)
+    case 'freebsd':
+    case 'linux':
+    case 'sunos':
+      return path.join(process.env.HOME, '.config', productName)
+    default:
+      throw new Error(`Unknown userDataPath path for platform ${process.platform}`)
+  }
+}
+
+const removeStoredPreferences = function () {
+  const userDataPath = getUserDataPath()
+  try {
+    fs.unlinkSync(path.join(userDataPath, 'Settings'))
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+
+module.exports = {
+  removeStoredPreferences,
+  getUserDataPath
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const fs = require('fs')
+const chaiAsPromised = require('chai-as-promised')
 
 const getUserDataPath = function () {
   const productName = require('../package').productName
@@ -17,7 +18,7 @@ const getUserDataPath = function () {
   }
 }
 
-const removeStoredPreferences = function () {
+const removeStoredPreferences = () => {
   const userDataPath = getUserDataPath()
   try {
     fs.unlinkSync(path.join(userDataPath, 'Settings'))
@@ -26,7 +27,55 @@ const removeStoredPreferences = function () {
   }
 }
 
+const setupApp = function (app) {
+  app.client.addCommand('dismissAboutPage', function () {
+    return this.isVisible('.js-nav').then(function (navVisible) {
+      if (!navVisible) {
+        return this.click('button[id="get-started"]').pause(500)
+      }
+    })
+  })
+
+  app.client.addCommand('selectSection', function (section) {
+    return this.click('button[data-section="' + section + '"]').pause(100)
+      .waitForVisible('#' + section + '-section')
+  })
+
+  app.client.addCommand('expandDemos', function () {
+    return this.execute(function () {
+      for (let demo of document.querySelectorAll('.demo-wrapper')) {
+        demo.classList.add('is-open')
+      }
+    })
+  })
+
+  app.client.addCommand('collapseDemos', function () {
+    return this.execute(function () {
+      for (let demo of document.querySelectorAll('.demo-wrapper')) {
+        demo.classList.remove('is-open')
+      }
+    })
+  })
+
+  app.client.addCommand('auditSectionAccessibility', function (section) {
+    const options = {
+      ignoreRules: ['AX_COLOR_01', 'AX_TITLE_01']
+    }
+    return this.selectSection(section)
+      .expandDemos()
+      .auditAccessibility(options).then(function (audit) {
+        if (audit.failed) {
+          throw Error(section + ' section failed accessibility audit\n' + audit.message)
+        }
+      })
+  })
+
+  chaiAsPromised.transferPromiseness = app.transferPromiseness
+  return app.client.waitUntilWindowLoaded()
+}
+
 module.exports = {
   removeStoredPreferences,
-  getUserDataPath
+  getUserDataPath,
+  setupApp
 }


### PR DESCRIPTION
Moved setup functions including 

```
removeStoredPreferences,
getUserDataPath,
setupApp
```
into another file so that they can be reused. Unsure if i should also move `startApp` and `restartApp` into `setup.js` for reusability?