### PR TITLE
replaces keyboard link with menu link

### DIFF
--- a/sections/menus/menus.html
+++ b/sections/menus/menus.html
@@ -32,7 +32,7 @@
             <p>When designing an app for multiple operating systems it's important to be mindful of the ways application menu conventions differ on each operating system.</p>
             <p>For instance, on Windows, accelerators are set with an <code>&</code>. Naming conventions also vary, like between "Settings" or "Preferences". Below are resources for learning operating system specific standards.</p>
             <ul>
-              <li><a href="https://developer.apple.com/macos/human-interface-guidelines/user-interaction/keyboard">macOS<span class="u-visible-to-screen-reader">(opens in new window)</span></a></li>
+              <li><a href="https://developer.apple.com/macos/human-interface-guidelines/menus/menu-anatomy/">macOS<span class="u-visible-to-screen-reader">(opens in new window)</span></a></li>
               <li><a href="https://msdn.microsoft.com/en-us/library/windows/desktop/bb226797(v=vs.85).aspx">Windows<span class="u-visible-to-screen-reader">(opens in new window)</span></a></li>
               <li><a href="https://developer.gnome.org/hig/stable/menu-bars.html.en">Linux<span class="u-visible-to-screen-reader">(opens in new window)</span></a></li>
             </ul>


### PR DESCRIPTION
I checked out the demo and the menu link was to the apple page for keyboards. Didn't really make sense to me.