### PR TITLE
bump electron devDependencies to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai-as-promised": "^6.0.0",
     "check-for-leaks": "^1.2.0",
     "devtron": "^1.3.0",
-    "electron": "~1.6.2",
+    "electron": "~1.8.2",
     "electron-packager": "^8.6.0",
     "electron-winstaller": "^2.2.0",
     "husky": "^0.14.3",


### PR DESCRIPTION
now that we have a stable 1.8.x version in npm, bump our dependency from to 1.8.x