### PR TITLE
Fix screenshot demo

### DIFF
--- a/renderer-process/media/desktop-capturer.js
+++ b/renderer-process/media/desktop-capturer.js
@@ -19,7 +19,7 @@ screenshot.addEventListener('click', (event) => {
       if (source.name === 'Entire screen' || source.name === 'Screen 1') {
         const screenshotPath = path.join(os.tmpdir(), 'screenshot.png')
 
-        fs.writeFile(screenshotPath, source.thumbnail.toPng(), (error) => {
+        fs.writeFile(screenshotPath, source.thumbnail.toPNG(), (error) => {
           if (error) return console.log(error)
           shell.openExternal(`file://${screenshotPath}`)
 


### PR DESCRIPTION
It was crashing on undefined 'NativeImage.toPng()', was deprecated (new version is NativeImage.toPNG()) in 1.7 and removed in 2.0.