### PR TITLE
Update to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai-as-promised": "^6.0.0",
     "check-for-leaks": "^1.2.0",
     "devtron": "^1.3.0",
-    "electron": "~1.8.2",
+    "electron": "^2.0.0",
     "electron-packager": "^8.6.0",
     "electron-winstaller": "^2.2.0",
     "husky": "^0.14.3",


### PR DESCRIPTION
Resolves https://github.com/electron/electron-api-demos/issues/357.

Update to Electron `v2.0.0` now that it's gone stable.

/cc @zeke @ckerr 
