### PR TITLE
feat: add a command-line-interface for launching

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+const {spawn} = require('child_process')
+const electron = require('electron')
+const path = require('path')
+
+const appPath = path.join(__dirname, 'main.js')
+const args = [appPath].concat(process.argv.slice(2))
+const proc = spawn(electron, args, {stdio: 'inherit'})
+
+proc.on('close', (code) => process.exit(code))

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ElectronAPIDemos",
+  "name": "electron-api-demos",
   "productName": "Electron API Demos",
   "version": "1.3.0",
   "description": "Electron interactive API demos",
-  "private": true,
   "main": "main.js",
+  "bin": "cli.js",
   "scripts": {
     "start": "electron .",
     "dev": "electron . --debug",


### PR DESCRIPTION
@codebytere had a great idea: what if we could install and launch the demos app right from the command line?!

This change moves us in that direction:

- [x] updates `name` to be a valid npm package name
- [x] removes `private` so package can be published to npm
- [x] adds a `bin` script

Once we publish this, folks should be able to run the demos app with `npx electron-api-demos`.

Caveat: this approach will essentially be running the application in "dev" mode, as if you were downloading the repo and running `npm install && npm start`. So the app icon will be the stock Electron icon, and the behavior of the app maybe be slightly different if there are an "dev vs packaged"  checks in the code.