### PR TITLE
update rgb2hex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4131,10 +4131,9 @@
       "dev": true
     },
     "rgb2hex": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.0.tgz",
-      "integrity": "sha1-zNVfhgrgxcTqN1BLlY5ELY0SMls=",
-      "dev": true
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.8.tgz",
+      "integrity": "sha512-kPH3Zm3UrBIfJv17AtJJGLRxak+Hvvz6SnsTBIajqB2Zbh+A4EEjkMWKkmGhms0cJlzOOjZcu1LX5K3vnON7ug=="
     },
     "rimraf": {
       "version": "2.6.2",


### PR DESCRIPTION
rgb2hex is subject to a RegExp-based Denial of Service vulnerability in
versions prior to 0.1.6. Update package-lock.json so `npm ci` and
friends install a safe version. No idea if electron is vulnerable to
anything remotely resembling a realistic attack based on this deep
dependency, but why bother looking into it when you can just update and
move on with life?

Refs: https://snyk.io/vuln/npm:rgb2hex:20180429