### PR TITLE
use current and LTS Node.js in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 
-node_js: "4"
+node_js:
+  - "node"
+  - "lts/*"
 
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
Update `.travis.yml` to use latest Node.js and an LTS release for
testing. Currently, Node.js 4.x is hard-coded. Node.js 4.x is currently
unsupported by the Node.js project. There will be no more 4.x releases.
Any security vulnerabilities or other bugs currently in 4.x will be there
forever.