### PR TITLE
fix: move electron to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-api-demos",
   "productName": "Electron API Demos",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Electron interactive API demos",
   "main": "main.js",
   "bin": "cli.js",
@@ -35,7 +35,6 @@
     "chai-as-promised": "^6.0.0",
     "check-for-leaks": "^1.2.0",
     "devtron": "^1.3.0",
-    "electron": "^2.0.4",
     "electron-packager": "^12.1.0",
     "electron-winstaller": "^2.2.0",
     "husky": "^0.14.3",
@@ -48,6 +47,7 @@
     "standard": "^8.2.0"
   },
   "dependencies": {
+    "electron": "^2.0.4",
     "electron-settings": "^3.0.7",
     "electron-shortcut-normalizer": "^1.0.0",
     "glob": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-api-demos",
   "productName": "Electron API Demos",
-  "version": "1.5.1",
+  "version": "1.5.0",
   "description": "Electron interactive API demos",
   "main": "main.js",
   "bin": "cli.js",


### PR DESCRIPTION
Refs: https://github.com/electron/electron-api-demos/issues/385
 
Fixes issue whereby we saw
```
$ npx electron-api-demos
Cannot find module 'electron'
```
by moving the `electron` dependency to from `devDeps` to `deps`.

/cc @zeke 