### PR TITLE
[wip] fix: specify repo explicitly for update-electron-app

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
 require('update-electron-app')({
-  logger: require('electron-log')
+  logger: require('electron-log'),
+  repo: 'electron/electron-api-demos'
 })
 
 const path = require('path')


### PR DESCRIPTION
Bypasses this by setting repo explicitly:

![image](https://user-images.githubusercontent.com/2289/44546146-e8da6980-a6cb-11e8-8aab-f841f9e99130.png)

cc @codebytere