### PR TITLE
fix: don't require update-electron-app if cli

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,6 +1,9 @@
-require('update-electron-app')({
-  logger: require('electron-log')
-})
+// only add update server if it's not being run from cli
+if (require.main !== module) {
+  require('update-electron-app')({
+    logger: require('electron-log')
+  })
+}
 
 const path = require('path')
 const glob = require('glob')


### PR DESCRIPTION
Potential fix for errors in `npx` and `npm` installation as a result of failed checks in `update-electron-app`.

/cc @zeke 
