### PR TITLE
fix: update deprecated makeSingleInstance

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,7 +75,9 @@ function initialize () {
 function makeSingleInstance () {
   if (process.mas) return false
 
-  return app.makeSingleInstance(() => {
+  app.requestSingleInstanceLock()
+
+  app.on('second-instance', () => {
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()


### PR DESCRIPTION
What it says on the tin.

Update deprecated `app.makeSingleInstance` to `app.requestSingleInstanceLock()` and `app.on('second-instance', cb)`