### PR TITLE
chore: clear code after start of requestSingleInstanceLock

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,8 +16,7 @@ if (process.mas) app.setName('Electron APIs')
 let mainWindow = null
 
 function initialize () {
-  const shouldQuit = makeSingleInstance()
-  if (shouldQuit) return app.quit()
+  makeSingleInstance()
 
   loadDemos()
 
@@ -73,7 +72,7 @@ function initialize () {
 // Returns true if the current version of the app should quit instead of
 // launching.
 function makeSingleInstance () {
-  if (process.mas) return false
+  if (process.mas) return
 
   app.requestSingleInstanceLock()
 


### PR DESCRIPTION
The PR removes unnecessary bits