### PR TITLE
chore: no longer explicitly wrap update-electron-app in check

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,6 @@ require('update-electron-app')({
   logger: require('electron-log')
 })
 
-
 const path = require('path')
 const glob = require('glob')
 const {app, BrowserWindow} = require('electron')

--- a/main.js
+++ b/main.js
@@ -1,9 +1,7 @@
-// only add update server if it's not being run from cli
-if (require.main !== module) {
-  require('update-electron-app')({
-    logger: require('electron-log')
-  })
-}
+require('update-electron-app')({
+  logger: require('electron-log')
+})
+
 
 const path = require('path')
 const glob = require('glob')


### PR DESCRIPTION
Follow-up to https://github.com/electron/electron-api-demos/pull/392.

Verdict: [`update-electron-app`](https://github.com/electron/update-electron-app/blob/master/index.js#L25) was using [`electron-is-dev`](https://github.com/sindresorhus/electron-is-dev/blob/master/index.js#L9) to determine whether or not the app was in dev mode and therefore whether or not to try and update – however! It was using `app.isPackaged` as a fallback! 

That API was not introduced until v3.0.0, and `electron-api-demos` itself wasn’t using `^3.0.0` until late October, so i believe it was returning an incorrect value as a result :rocket:

/cc @zeke @ckerr