### PR TITLE
chore: update release script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,56 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@octokit/endpoint": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.1.tgz",
+      "integrity": "sha512-KPkoTvKwCTetu/UqonLs1pfwFO5HAqTv/Ksp9y4NAg//ZgUCpvJsT4Hrst85uEzJvkB8+LxKyR4Bfv2X8O4cmQ==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "3.0.0",
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
+          "integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.2.1.tgz",
+      "integrity": "sha512-enwbVOl3vWWIUuEj0LJRq+mxWNyv95fa13GJitz7qGt/ycYCwtSoVssW3pCqvxS4GlJfHfO2OA+8czIcEF522A==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^3.1.1",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.3.2.tgz",
+      "integrity": "sha512-g1Shr7Bp5K3+o1VdUvQn//8ZIAFFODBi9GFdx4eqV2qZQtWwy28jmCGuS+CphnCj8PlQbFmZtXvmUh5xIRGFcA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "2.2.1",
+        "before-after-hook": "^1.2.0",
+        "btoa-lite": "^1.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.pick": "^4.4.0",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
+      }
+    },
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
@@ -397,6 +447,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "before-after-hook": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.1.tgz",
+      "integrity": "sha512-BIjg60OP/sQvG7Q2L9Xkc77gyyFw1B4T73LIfZVQtXbutJinC1+t2HRl4qeR3EWAmY+tA6z9vpRi02q6ZXyluQ==",
+      "dev": true
+    },
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
@@ -479,6 +535,12 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
     "buffer": {
@@ -1759,6 +1821,21 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "execa": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "exit-hook": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
@@ -2156,6 +2233,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "getpass": {
       "version": "0.1.7",
@@ -2605,6 +2688,23 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -2642,6 +2742,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
@@ -2922,6 +3028,18 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -2941,6 +3059,12 @@
         "lodash._reinterpolate": "~3.0.0"
       }
     },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -2949,6 +3073,12 @@
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
       }
+    },
+    "macos-release": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+      "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
@@ -3193,6 +3323,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
+      "dev": true
+    },
     "nodeify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
@@ -3311,6 +3447,15 @@
         }
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "nugget": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
@@ -3369,6 +3514,12 @@
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
       }
+    },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -3442,10 +3593,26 @@
         "lcid": "^1.0.0"
       }
     },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-limit": {
@@ -4335,6 +4502,12 @@
         "is-utf8": "^0.2.0"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -4671,6 +4844,15 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
+    "universal-user-agent": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.2.tgz",
+      "integrity": "sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.0.0"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -4718,6 +4900,12 @@
           "dev": true
         }
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     },
     "user-home": {
       "version": "2.0.0",
@@ -4866,6 +5054,15 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
       "dev": true
+    },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.10.0"
+      }
     },
     "winston": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "GitHub",
   "license": "MIT",
   "devDependencies": {
+    "@octokit/rest": "^16.3.2",
     "chai": "^3.4.1",
     "chai-as-promised": "^6.0.0",
     "check-for-leaks": "^1.2.0",

--- a/script/release.js
+++ b/script/release.js
@@ -126,7 +126,7 @@ async function uploadAssets (release, assets) {
           console.error('\n')
           console.error(`  There was a network timeout while uploading ${asset.name}.`)
           console.error('  This likely resulted in a bad asset; please visit the release at')
-          console.error(`  ${release.html_url} and manually removed the bad asset,`)
+          console.error(`  ${release.html_url} and manually remove the bad asset,`)
           console.error(`  then run this script again to continue where you left off.`)
           console.error('')
           process.exit(2)

--- a/script/release.js
+++ b/script/release.js
@@ -3,54 +3,39 @@
 const childProcess = require('child_process')
 const fs = require('fs')
 const path = require('path')
-const request = require('request')
-const util = require('util')
+const octokit = require('@octokit/rest')
 
 const token = process.env.ELECTRON_API_DEMO_GITHUB_TOKEN
 const version = require('../package').version
+const github = octokit({
+  timeout: 30 * 1000,
+  'user-agent': `node/${process.versions.node}`
+})
 
-checkToken()
-  .then(zipAssets)
-  .then(createRelease)
-  .then(uploadAssets)
-  .then(publishRelease)
-  .catch((error) => {
-    console.error(error.message || error)
-    process.exit(1)
-  })
-
-function checkToken () {
-  if (!token) {
-    return Promise.reject('ELECTRON_API_DEMO_GITHUB_TOKEN environment variable not set\nSet it to a token with repo scope created from https://github.com/settings/tokens/new')
-  } else {
-    return Promise.resolve(token)
-  }
+if (!token) {
+  console.error('ELECTRON_API_DEMO_GITHUB_TOKEN environment variable not set\nSet it to a token with repo scope created from https://github.com/settings/tokens/new')
+  process.exit(1)
 }
 
-function zipAsset (asset) {
-  return new Promise((resolve, reject) => {
-    const assetBase = path.basename(asset.path)
-    const assetDirectory = path.dirname(asset.path)
-    console.log(`Zipping ${assetBase} to ${asset.name}`)
+github.authenticate({
+  type: 'token',
+  token: token
+})
 
-    if (!fs.existsSync(asset.path)) {
-      return reject(new Error(`${asset.path} does not exist`))
-    }
-
-    const zipCommand = `zip --recurse-paths --symlinks '${asset.name}' '${assetBase}'`
-    const options = {cwd: assetDirectory, maxBuffer: Infinity}
-    childProcess.exec(zipCommand, options, (error) => {
-      if (error) {
-        reject(error)
-      } else {
-        asset.path = path.join(assetDirectory, asset.name)
-        resolve(asset)
-      }
-    })
-  })
+async function doRelease () {
+  const release = await getOrCreateRelease()
+  const assets = await prepareAssets()
+  await uploadAssets(release, assets)
+  await publishRelease(release)
+  console.log('Done!')
 }
 
-function zipAssets () {
+doRelease().catch(err => {
+  console.error(err.message || err)
+  process.exit(1)
+})
+
+function prepareAssets () {
   const outPath = path.join(__dirname, '..', 'out')
 
   const zipAssets = [{
@@ -78,97 +63,103 @@ function zipAssets () {
   })
 }
 
-function createRelease (assets) {
-  const options = {
-    uri: 'https://api.github.com/repos/electron/electron-api-demos/releases',
-    headers: {
-      Authorization: `token ${token}`,
-      'User-Agent': `node/${process.versions.node}`
-    },
-    json: {
-      tag_name: `v${version}`,
-      target_commitish: 'master',
-      name: version,
-      body: 'An awesome new release :tada:',
-      draft: true,
-      prerelease: false
-    }
-  }
-
+function zipAsset (asset) {
   return new Promise((resolve, reject) => {
-    console.log('Creating new draft release')
+    const assetBase = path.basename(asset.path)
+    const assetDirectory = path.dirname(asset.path)
+    console.log(`Zipping ${assetBase} to ${asset.name}`)
 
-    request.post(options, (error, response, body) => {
+    if (!fs.existsSync(asset.path)) {
+      return reject(new Error(`${asset.path} does not exist`))
+    }
+
+    const zipCommand = `zip --recurse-paths --symlinks '${asset.name}' '${assetBase}'`
+    const options = {cwd: assetDirectory, maxBuffer: Infinity}
+    childProcess.exec(zipCommand, options, (error) => {
       if (error) {
-        return reject(Error(`Request failed: ${error.message || error}`))
+        reject(error)
+      } else {
+        asset.path = path.join(assetDirectory, asset.name)
+        resolve(asset)
       }
-      if (response.statusCode !== 201) {
-        return reject(Error(`Non-201 response: ${response.statusCode}\n${util.inspect(body)}`))
-      }
-
-      resolve({assets: assets, draft: body})
     })
   })
+}
+
+async function getOrCreateRelease () {
+  const { data: releases } = await github.repos.listReleases({
+    owner: 'electron',
+    repo: 'electron-api-demos',
+    per_page: 100,
+    page: 1
+  })
+  const existingRelease = releases.find(release => release.tag_name === `v${version}` && release.draft === true)
+  if (existingRelease) {
+    console.log(`Using existing draft release for v${version}`)
+    return existingRelease
+  }
+
+  console.log('Creating new draft release')
+  const { data: release } = await github.repos.createRelease({
+    owner: 'electron',
+    repo: 'electron-api-demos',
+    tag_name: `v${version}`,
+    target_commitish: 'master',
+    name: version,
+    body: 'An awesome new release :tada:',
+    draft: true,
+    prerelease: false
+  })
+  return release
+}
+
+async function uploadAssets (release, assets) {
+  for (const asset of assets) {
+    if (release.assets.some(ghAsset => ghAsset.name === asset.name)) {
+      console.log(`Skipping already uploaded asset ${asset.name}`)
+    } else {
+      process.stdout.write(`Uploading ${asset.name}... `)
+      try {
+        await uploadAsset(release, asset)
+      } catch (err) {
+        if (err.name === 'HttpError' && err.message.startsWith('network timeout')) {
+          console.error('\n')
+          console.error(`  There was a network timeout while uploading ${asset.name}.`)
+          console.error('  This likely resulted in a bad asset; please visit the release at')
+          console.error(`  ${release.html_url} and manually removed the bad asset,`)
+          console.error(`  then run this script again to continue where you left off.`)
+          console.error('')
+          process.exit(2)
+        } else {
+          throw err
+        }
+      }
+
+      process.stdout.write('Success!\n')
+      // [mkt] Waiting a bit between uploads seems to increase success rate
+      await new Promise(resolve => setTimeout(resolve, 5000))
+    }
+  }
 }
 
 function uploadAsset (release, asset) {
-  const options = {
-    uri: release.upload_url.replace(/\{.*$/, `?name=${asset.name}`),
+  return github.repos.uploadReleaseAsset({
     headers: {
-      Authorization: `token ${token}`,
-      'Content-Type': 'application/zip',
-      'Content-Length': fs.statSync(asset.path).size,
-      'User-Agent': `node/${process.versions.node}`
-    }
-  }
-
-  return new Promise((resolve, reject) => {
-    console.log(`Uploading ${asset.name} as release asset`)
-
-    const assetRequest = request.post(options, (error, response, body) => {
-      if (error) {
-        return reject(Error(`Uploading asset failed: ${error.message || error}`))
-      }
-      if (response.statusCode >= 400) {
-        return reject(Error(`400+ response: ${response.statusCode}\n${util.inspect(body)}`))
-      }
-
-      resolve(asset)
-    })
-    fs.createReadStream(asset.path).pipe(assetRequest)
+      'content-type': 'application/octet-stream',
+      'content-length': fs.statSync(asset.path).size
+    },
+    url: release.upload_url,
+    file: fs.createReadStream(asset.path),
+    name: asset.name
   })
 }
 
-function uploadAssets (release) {
-  return Promise.all(release.assets.map((asset) => {
-    return uploadAsset(release.draft, asset)
-  })).then(() => release)
-}
-
 function publishRelease (release) {
-  const options = {
-    uri: release.draft.url,
-    headers: {
-      Authorization: `token ${token}`,
-      'User-Agent': `node/${process.versions.node}`
-    },
-    json: {
-      draft: false
-    }
-  }
-
-  return new Promise((resolve, reject) => {
-    console.log('Publishing release')
-
-    request.post(options, (error, response, body) => {
-      if (error) {
-        return reject(Error(`Request failed: ${error.message || error}`))
-      }
-      if (response.statusCode !== 200) {
-        return reject(Error(`Non-200 response: ${response.statusCode}\n${util.inspect(body)}`))
-      }
-
-      resolve(body)
-    })
+  console.log('Publishing release')
+  return github.repos.updateRelease({
+    owner: 'electron',
+    repo: 'electron-api-demos',
+    release_id: release.id,
+    draft: false
   })
 }


### PR DESCRIPTION
This PR updates the release script:

* Use `async`/`await` everywhere
* Use `@octokit/rest` instead of manual requests
* "Gracefully" handle GitHub asset upload failures

    Until this is fixed on GitHub's end, the best we can do is prompt the releaser to manually delete the incomplete asset from the draft release and try again