### PR TITLE
fix: enable node integration

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,10 @@ function initialize () {
       width: 1080,
       minWidth: 680,
       height: 840,
-      title: app.getName()
+      title: app.getName(),
+      webPreferences: {
+        nodeIntegration: true
+      }
     }
 
     if (process.platform === 'linux') {


### PR DESCRIPTION
Needed for the current code structure, but disabled by default in 5.0.

CC @codebytere 