### PR TITLE
fix: crash and hang demos

### DIFF
--- a/renderer-process/windows/process-crash.js
+++ b/renderer-process/windows/process-crash.js
@@ -5,7 +5,13 @@ const processCrashBtn = document.getElementById('process-crash')
 
 processCrashBtn.addEventListener('click', (event) => {
   const crashWinPath = path.join('file://', __dirname, '../../sections/windows/process-crash.html')
-  let win = new BrowserWindow({ width: 400, height: 320 })
+  let win = new BrowserWindow({
+    width: 400,
+    height: 320,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  });
 
   win.webContents.on('crashed', () => {
     const options = {

--- a/renderer-process/windows/process-hang.js
+++ b/renderer-process/windows/process-hang.js
@@ -5,7 +5,13 @@ const processHangBtn = document.getElementById('process-hang')
 
 processHangBtn.addEventListener('click', (event) => {
   const hangWinPath = path.join('file://', __dirname, '../../sections/windows/process-hang.html')
-  let win = new BrowserWindow({ width: 400, height: 320 })
+  let win = new BrowserWindow({
+    width: 400,
+    height: 320,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  });
 
   win.on('unresponsive', () => {
     const options = {


### PR DESCRIPTION
Hi! 👋
I've noticed, that crash and hang demos do not work and there's `process is not defined` errors in demo windows.

This PR fixes that by enabling node integration, so demo windows have access to `process`.