### PR TITLE
fix: enable node integration to make invisible window demo work

### DIFF
--- a/renderer-process/communication/invisible-msg.js
+++ b/renderer-process/communication/invisible-msg.js
@@ -11,7 +11,10 @@ invisMsgBtn.addEventListener('click', (clickEvent) => {
   let win = new BrowserWindow({
     width: 400,
     height: 400,
-    show: false
+    show: false,
+    webPreferences: {
+      nodeIntegration: true
+    }
   })
   win.loadURL(invisPath)
 


### PR DESCRIPTION
Same as #429, but for invisible window demo