### PR TITLE
fix: case error in desktop-capturer demo

### DIFF
--- a/renderer-process/media/desktop-capturer.js
+++ b/renderer-process/media/desktop-capturer.js
@@ -16,7 +16,7 @@ screenshot.addEventListener('click', (event) => {
     if (error) return console.log(error)
 
     sources.forEach((source) => {
-      if (source.name === 'Entire screen' || source.name === 'Screen 1') {
+      if (source.name === 'Entire Screen' || source.name === 'Screen 1') {
         const screenshotPath = path.join(os.tmpdir(), 'screenshot.png')
 
         fs.writeFile(screenshotPath, source.thumbnail.toPNG(), (error) => {


### PR DESCRIPTION
The desktop-capturer demo not working in my mac. After debugging, I think there is a case error in the code.