### PR TITLE
fix: Cannot read property 'getPrimaryDisplay' of undefined

### DIFF
--- a/renderer-process/media/desktop-capturer.js
+++ b/renderer-process/media/desktop-capturer.js
@@ -1,4 +1,5 @@
-const {desktopCapturer, screen, shell} = require('electron')
+const {desktopCapturer, shell} = require('electron')
+const {screen} = require('electron').remote
 
 const fs = require('fs')
 const os = require('os')

--- a/renderer-process/system/screen-information.js
+++ b/renderer-process/system/screen-information.js
@@ -1,4 +1,4 @@
-const {screen} = require('electron')
+const {screen} = require('electron').remote
 
 const screenInfoBtn = document.getElementById('screen-info')
 const size = screen.getPrimaryDisplay().size


### PR DESCRIPTION
renderer process accesses main process using remote module